### PR TITLE
Start addressing #65

### DIFF
--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -140,21 +140,20 @@ class TestSimulated(unittest.TestCase):
         dated_ts = tsdate.date(ts, Ne=1)
         self.ts_equal_except_times(ts, dated_ts)
 
-    @unittest.skip("Need to address https://github.com/awohns/tsdate/issues/65")
-    def test_1_tree_with_dangling(self):
-        ts = msprime.simulate(8, mutation_rate=5, random_seed=2)
-        tables = ts.dump_tables()
-        tables.edges.clear()
-        # remove all links to a few samples, to leave dangling nodes
-        for e in ts.tables.edges:
-            if e.child not in set([0, 3, 6, 7]):
-                tables.edges.add_row(e.left, e.right, e.parent, e.child)
-        dangling_node_ts = tables.tree_sequence()
-        # Check we have an internal node with no samples
-        tree = dangling_node_ts.first()
-        assert any(tree.num_samples(u) == 0 for u in tree.nodes())
+    def test_half_dangling_node(self):
+        dangling_node_ts, dangling_node = utility_functions.half_dangling_ts()
         dated_ts = tsdate.date(dangling_node_ts, Ne=1)
         self.ts_equal_except_times(dangling_node_ts, dated_ts)
+
+    def test_dangling_node(self):
+        dangling_node_ts, dangling_node = utility_functions.dangling_ts()
+        self.assertRaises(RuntimeError, tsdate.date, dangling_node_ts, Ne=1)
+        # self.ts_equal_except_times(dangling_node_ts, dated_ts)
+
+    def test_dangling_node_with_missing(self):
+        dangling_node_ts, dangling_node = utility_functions.dangling_missing_ts()
+        self.assertRaises(RuntimeError, tsdate.date, dangling_node_ts, Ne=1)
+        # self.ts_equal_except_times(dangling_node_ts, dated_ts)
 
     def test_non_contemporaneous(self):
         samples = [

--- a/tests/utility_functions.py
+++ b/tests/utility_functions.py
@@ -230,6 +230,51 @@ def two_tree_mutation_ts():
                            mutations=mutations, strict=False)
 
 
+def non_sample_external_nodes_ts():
+    """
+    Simplest case where we have n = 2 and external non-sample nodes.
+           _ 2 _
+          / / | \
+         / |  |  \
+        0  1  3  4
+
+        s  s
+        a  a
+        m  m
+        p  p
+        l  l
+        e  e
+    """
+    nodes = io.StringIO("""\
+    id      is_sample   time
+    0       1           0
+    1       1           0
+    2       0           1
+    3       0           0
+    4       0           0
+    """)
+    edges = io.StringIO("""\
+    left    right   parent  child
+    0       1       2       0,1,3,4
+    """)
+    sites = io.StringIO("""\
+    id  position    ancestral_state
+    0   0.1         0
+    1   0.2         0
+    2   0.3         0
+    3   0.4         0
+    """)
+    mutations = io.StringIO("""\
+    site    node    derived_state
+    0       0       1
+    1       1       1
+    2       3       1
+    3       4       1
+    """)
+    return tskit.load_text(
+        nodes=nodes, edges=edges, sites=sites, mutations=mutations, strict=False)
+
+
 def truncate_ts_samples(ts, average_span, random_seed, min_span=5):
     """
     Create a tree sequence that has sample nodes which have been truncated


### PR DESCRIPTION
We still need to deal with NaNs in the forwards matrix when calling `backward_algorithm()`. These should mark dangling nodes, although I'm slightly worried that other bugs might cause NaNs too, so perhaps that isn't such a good convention to establish. Other suggestions welcome (perhaps np.inf?)