### PR TITLE
added support for internal samples, more tests coming

### DIFF
--- a/tests/utility_functions.py
+++ b/tests/utility_functions.py
@@ -125,6 +125,31 @@ def polytomy_tree_ts():
     return tskit.load_text(nodes=nodes, edges=edges, strict=False)
 
 
+def single_tree_ts_n3_internal_sample():
+    r"""
+    Simple case where we have n = 3 and one tree.
+            4
+           / \
+          3   \
+         / \   \
+        0   1   2
+    """
+    nodes = io.StringIO("""\
+    id      is_sample   time
+    0       1           0
+    1       1           0
+    2       1           0
+    3       1           1
+    4       0           2
+    """)
+    edges = io.StringIO("""\
+    left    right   parent  child
+    0       1       3       0,1
+    0       1       4       2,3
+    """)
+    return tskit.load_text(nodes=nodes, edges=edges, strict=False)
+
+
 def two_tree_ts():
     r"""
     Simple case where we have n = 3 and 2 trees.

--- a/tsdate/__init__.py
+++ b/tsdate/__init__.py
@@ -24,7 +24,7 @@ from .date import (  # NOQA
     date, restrict_ages_topo, return_ts, create_time_grid,
     get_prior_values, upward_algorithm, ConditionalCoalescentTimes, SpansBySamples,
     posterior_mean_var, gamma_approx, get_mixture_prior, iterate_parent_edges,
-    downward_algorithm, Likelihoods)
+    downward_algorithm, Likelihoods, FixedSamples)
 
 
 from .provenance import __version__  # NOQA

--- a/tsdate/date.py
+++ b/tsdate/date.py
@@ -59,6 +59,7 @@ class FixedSamples:
         self.ancient_grid_times = np.abs(grid[:, None] -
                                          ancient_sample_times).argmin(axis=0)
 
+
 def gamma_approx(mean, variance):
     """
     Returns alpha and beta of a gamma distribution for a given mean and variance


### PR DESCRIPTION
Supports internal nodes. Creates a new class to store the identity and time of ancient and modern nodes. Upward and backward algorithms properly handle these fixed nodes (skipping them in the recursion). One test so far of how internal nodes are handled in the upward algorithm, will add more now. 