### PR TITLE
Switch to only storing fixed node data in Prior

### DIFF
--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -189,7 +189,7 @@ class TestNodeTipWeights(unittest.TestCase):
         self.verify_weights(ts)
 
     def test_dangling_nodes_warn(self):
-        ts = utility_functions.single_tree_ts_n3_dangling()
+        ts = utility_functions.single_tree_ts_n2_dangling()
         with self.assertLogs(level="WARNING") as log:
             self.verify_weights(ts)
             self.assertGreater(len(log.output), 0)
@@ -434,6 +434,17 @@ class TestMixturePrior(unittest.TestCase):
         self.assertTrue(
             np.allclose(mixture_prior[4, self.alpha_beta], [0.11111, 0.55555]))
 
+    def test_simulated_non_contemporaneous(self):
+        samples = [
+            msprime.Sample(population=0, time=0),
+            msprime.Sample(population=0, time=0),
+            msprime.Sample(population=0, time=0),
+            msprime.Sample(population=0, time=1.0)
+        ]
+        ts = msprime.simulate(samples=samples, Ne=1, mutation_rate=2, random_seed=123)
+        self.get_mixture_prior_params(ts, 'lognorm')
+        self.get_mixture_prior_params(ts, 'gamma')
+
 
 class TestPriorVals(unittest.TestCase):
     def verify_prior_vals(self, ts, prior_distr):
@@ -489,6 +500,18 @@ class TestPriorVals(unittest.TestCase):
         ts = utility_functions.two_tree_ts_n3_non_contemporaneous()
         prior_vals = self.verify_prior_vals(ts, 'gamma')
         self.assertEqual(prior_vals.fixed_time(2), ts.node(2).time)
+
+    def test_simulated_non_contemporaneous(self):
+        samples = [
+            msprime.Sample(population=0, time=0),
+            msprime.Sample(population=0, time=0),
+            msprime.Sample(population=0, time=0),
+            msprime.Sample(population=0, time=1.0)
+        ]
+        ts = msprime.simulate(samples=samples, Ne=1, mutation_rate=2, random_seed=123)
+        prior_vals = self.verify_prior_vals(ts, 'gamma')
+        print(prior_vals.timepoints)
+        raise
 
 
 class TestLikelihoodClass(unittest.TestCase):
@@ -789,7 +812,7 @@ class TestAlgorithmClass(unittest.TestCase):
 
     def test_nonmatching_prior_vs_lik_fixednodes(self):
         ts1 = utility_functions.single_tree_ts_n3()
-        ts2 = utility_functions.single_tree_ts_n3_dangling()
+        ts2 = utility_functions.single_tree_ts_n2_dangling()
         timepoints = np.array([0, 1.2, 2])
         prior = tsdate.build_prior_grid(ts1, timepoints)
         lls = Likelihoods(ts2, prior.timepoints)
@@ -901,7 +924,7 @@ class TestInsideAlgorithm(unittest.TestCase):
         self.assertTrue(np.allclose(algo.inside[5], np.array([0, 7.06320034e-11, 1])))
 
     def test_dangling_fails(self):
-        ts = utility_functions.single_tree_ts_n3_dangling()
+        ts = utility_functions.single_tree_ts_n2_dangling()
         print(ts.draw_text())
         print("Samples:", ts.samples())
         prior = tsdate.build_prior_grid(ts, timepoints=np.array([0, 1.2, 2]))

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -48,7 +48,7 @@ class TestPrebuilt(unittest.TestCase):
             self.assertEqual(len(log.output), 1)
             self.assertIn("unary nodes", log.output[0])
 
-    def test_fails_with_recombination(self):
+    def test_fails_with_recombination_clock(self):
         ts = utility_functions.two_tree_mutation_ts()
         for probability_space in (LOG, LIN):
             self.assertRaises(
@@ -57,6 +57,12 @@ class TestPrebuilt(unittest.TestCase):
             self.assertRaises(
                 NotImplementedError, tsdate.date, ts, Ne=1, recombination_rate=1,
                 probability_space=probability_space, mutation_rate=1)
+
+    def test_non_contemporaneous(self):
+        ts = utility_functions.two_tree_ts_n3_non_contemporaneous()
+        theta = 2
+        ts = msprime.mutate(ts, rate=theta)
+        tsdate.date(ts, Ne=1, mutation_rate=theta, probability_space=LIN)
 
 #     def test_simple_ts_n2(self):
 #         ts = utility_functions.single_tree_ts_n2()
@@ -209,7 +215,8 @@ class TestSimulated(unittest.TestCase):
             msprime.Sample(population=0, time=0),
             msprime.Sample(population=0, time=1.0)
         ]
-        ts = msprime.simulate(samples=samples, Ne=1, mutation_rate=2)
+        ts = msprime.simulate(samples=samples, Ne=1, mutation_rate=2, random_seed=123)
+        print(ts.draw_text())
         self.assertRaises(NotImplementedError, tsdate.date, ts, 1, 2)
 
     @unittest.skip("YAN to fix")

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -39,7 +39,7 @@ class TestPrebuilt(unittest.TestCase):
     Tests for tsdate on prebuilt tree sequences
     """
     def test_dangling_failure(self):
-        ts = utility_functions.single_tree_ts_n3_dangling()
+        ts = utility_functions.single_tree_ts_n2_dangling()
         self.assertRaisesRegexp(ValueError, "dangling", tsdate.date, ts, Ne=1)
 
     def test_unary_warning(self):

--- a/tests/utility_functions.py
+++ b/tests/utility_functions.py
@@ -44,10 +44,10 @@ def add_grand_mrca(ts):
 
 def single_tree_ts_n2():
     r"""
-    Simple case where we have n = 2 and one tree.
+    Simple case where we have n = 2 and one tree. [] marks a sample
          2
         / \
-       0   1
+      [0] [1]
     """
     nodes = io.StringIO("""\
     id      is_sample   time
@@ -69,7 +69,7 @@ def single_tree_ts_n3():
            / \
           3   \
          / \   \
-        0   1   2
+       [0] [1] [2]
     """
     nodes = io.StringIO("""\
     id      is_sample   time
@@ -96,7 +96,7 @@ def single_tree_ts_n4():
            / \   \
           4   \   \
          / \   \   \
-        0   1   2   3
+       [0] [1] [2] [3]
     """
     nodes = io.StringIO("""\
     id      is_sample   time
@@ -124,7 +124,7 @@ def single_tree_ts_mutation_n3():
            / \
           3   x
          / \   \
-        0   1   2
+       [0] [1] [2]
     """
     nodes = io.StringIO("""\
     id      is_sample   time
@@ -158,7 +158,7 @@ def single_tree_all_samples_one_mutation_n3():
            / \
           3   x
          / \   \
-        0   1   2
+       [0] [1] [2]
     """
     nodes = io.StringIO("""\
     id      is_sample   time
@@ -188,16 +188,16 @@ def single_tree_all_samples_one_mutation_n3():
 def gils_example_tree():
     r"""
     Simple case where we have n = 3 and one tree.
-    Number of mutations on each branch are in parentheses.
+    Mutations marked on each branch by *.
              4
             / \
-          (0)  \
-          /    (4)
-         3       \
-        / \       \
-      (2) (1)      \
-      /     \       \
-     0       1       2
+           /   \
+          /     *
+         3       *
+        / \       *
+       *   *       *
+      *     \       \
+    [0]     [1]     [2]
     """
     nodes = io.StringIO("""\
     id      is_sample   time
@@ -241,7 +241,8 @@ def polytomy_tree_ts():
     Simple case where we have n = 3 and a polytomy.
           3
          /|\
-        0 1 2
+        / | \
+      [0][1][2]
     """
     nodes = io.StringIO("""\
     id      is_sample   time
@@ -264,7 +265,7 @@ def single_tree_ts_internal_n3():
            / \
           3   \
          / \   \
-        0   1   2
+       [0] [1] [2]
     """
     nodes = io.StringIO("""\
     id      is_sample   time
@@ -291,7 +292,7 @@ def two_tree_ts():
            / \     .  |   |\
           3   \    .  |   | \
          / \   \   .  |   |  \
-        0   1   2  .  0   1   2
+       [0] [1] [2] . [0] [1] [2]
     """
     nodes = io.StringIO("""\
     id      is_sample   time
@@ -313,6 +314,25 @@ def two_tree_ts():
     return tskit.load_text(nodes=nodes, edges=edges, strict=False)
 
 
+def two_tree_ts_n3_non_contemporaneous():
+    r"""
+    Simple case where we have n = 3 and two trees with node 2 ancient.
+                   .    5
+                   .   / \
+            4      .  |   4
+           / \     .  |   |\
+          3  [2]   .  |   |[2]
+         / \       .  |   |
+       [0] [1]     . [0] [1]
+    """
+    ts = two_tree_ts()
+    tables = ts.dump_tables()
+    time = tables.nodes.time
+    time[2] = time[3]
+    tables.nodes.time = time
+    return tables.tree_sequence()
+
+
 def single_tree_ts_with_unary():
     r"""
     Simple case where we have n = 3 and some unary nodes.
@@ -324,7 +344,7 @@ def single_tree_ts_with_unary():
           |     |
           3     |
          / \    |
-        0   1   2
+       [0] [1] [2]
     """
     nodes = io.StringIO("""\
     id      is_sample   time
@@ -360,7 +380,7 @@ def two_tree_mutation_ts():
         /      |   .   |   |   |
        3       |   .   |   |   |
       / \      |   .   |   |   |
-     0   1     2   .   0   1   2
+    [0] [1]   [2]  .  [0] [1] [2]
     """
     nodes = io.StringIO("""\
     id      is_sample   time
@@ -407,8 +427,7 @@ def two_tree_two_mrcas():
        4           5       |       4         5
       / \         / \      |      / \       / \
      /   \       /   \     |     /   \     /   \
-    |     |     |     |    |    |     |   |     |
-    0     1     2     3    |    0     1   2     3
+   [0]   [1]   [2]   [3]   |   [0]   [1] [2]   [3]
     """
     nodes = io.StringIO("""\
     id      is_sample   time
@@ -438,17 +457,17 @@ def loopy_tree():
     Simple case where we have n = 3, 2 trees, three mutations.
                    .          7
                    .         / \
-                   .        /  |
-                   .       /   |
-         6         .      /    6
-        / \        .     /    / \
-       /   5       .    /    /   |
-      /   / \      .   /    /    |
-     |   /   \     .  |    |     |
-     |   |    \    .  |    |     |
-     |   4     |    . |    4     |
-     |  / \    |    . |   / \    |
-     0 1   2   3    . 0  1   2   3
+                   .        /   |
+                   .       /    |
+         6         .      /     6
+        / \        .     /     / \
+       /   5       .    /     /   |
+      /   / \      .   /     /    |
+     /   |   \     .  |     |     |
+    /    |    \    .  |     |     |
+   |     4     |   .  |     4     |
+   |    / \    |   .  |    / \    |
+  [0] [1] [2] [3]  . [0] [1] [2] [3]
     """
     nodes = io.StringIO("""\
     id      is_sample   time
@@ -481,7 +500,7 @@ def single_tree_ts_n3_sample_as_parent():
            / \
           3   \
          / \   \
-        0   1   2
+       [0] [1] [2]
     """
     nodes = io.StringIO("""\
     id      is_sample   time
@@ -499,14 +518,58 @@ def single_tree_ts_n3_sample_as_parent():
     return tskit.load_text(nodes=nodes, edges=edges, strict=False)
 
 
-def single_tree_ts_n3_dangling():
-    # Mark node 0 as a non-sample node, which should make it dangling
-    ts = single_tree_ts_n3()
-    tables = ts.dump_tables()
-    flags = tables.nodes.flags
-    flags[0] = flags[0] & (~tskit.NODE_IS_SAMPLE)
-    tables.nodes.flags = flags
-    return tables.tree_sequence()
+def single_tree_ts_n2_dangling():
+    r"""
+    Simple case where we have n = 2 and one tree. Node 0 is dangling.
+            4
+           / \
+          3   \
+         / \   \
+        0  [1] [2]
+    """
+    nodes = io.StringIO("""\
+    id      is_sample   time
+    0       0           0
+    1       1           0
+    2       1           0
+    3       0           1
+    4       0           2
+    """)
+    edges = io.StringIO("""\
+    left    right   parent  child
+    0       1       3       0,1
+    0       1       4       2,3
+    """)
+    return tskit.load_text(nodes=nodes, edges=edges, strict=False)
+
+
+def two_tree_ts_n2_part_dangling():
+    r"""
+    Simple case where we have n = 2 and two trees. Node 0 is dangling in the first tree.
+            4                 4
+           / \               / \
+          3   \             3   \
+         / \   \             \   \
+        0   \   \             0   \
+             \   \             \   \
+             [1] [2]           [1] [2]
+    """
+    nodes = io.StringIO("""\
+    id      is_sample   time
+    0       0           0.5
+    1       1           0
+    2       1           0
+    3       1           1
+    4       0           2
+    """)
+    edges = io.StringIO("""\
+    left    right   parent  child
+    0       1       3       0
+    0       0.5     3       1
+    0.5     1       0       1
+    0       1       4       2,3
+    """)
+    return tskit.load_text(nodes=nodes, edges=edges, strict=False)
 
 
 def truncate_ts_samples(ts, average_span, random_seed, min_span=5):


### PR DESCRIPTION
I realised belatedly that fixed nodes do not need to store likelihood values for the prior, but *times* - i.e. all the likelihood is concentrated at a precise time (not just a time slice, but a floating point time value). Additionally, we don't want to change this during the inside or outside pass. So I've changed the NodeGridValues class to take out the fixed node stuff, and created a new `Prior` subclass that adds the ability to store a time (*not* a likelihood) for fixed nodes.

This is not for merging yet - it is the first iteration of incorporating non-contemporaneous samples into tsdate.