### PR TITLE
Use tskit num_children() method

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
+tskit>=0.3.0
 flake8
 nose
 numpy
 tqdm
 daiquiri
 msprime
-tskit
 scipy
 codecov
 numba

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -183,6 +183,20 @@ class TestNodeTipWeights(unittest.TestCase):
         self.assertEqual(span_data.lookup_weight(4, n, 3), 0.25)
         self.assertEqual(span_data.lookup_weight(3, n, 2), 1.0)
 
+    @unittest.skip("Unary node is internal then the oldest node")
+    def test_tree_with_unary_nodes_oldest(self):
+        ts = utility_functions.two_tree_ts_with_unary_n3()
+        n = ts.num_samples
+        span_data = self.verify_weights(ts)
+        self.assertEqual(span_data.lookup_weight(9, n, 4), 0.5)
+        self.assertEqual(span_data.lookup_weight(8, n, 4), 1.0)
+        self.assertEqual(span_data.lookup_weight(7, n, 1), 0.5)
+        self.assertEqual(span_data.lookup_weight(7, n, 4), 0.5)
+        self.assertEqual(span_data.lookup_weight(6, n, 2), 0.5)
+        self.assertEqual(span_data.lookup_weight(6, n, 4), 0.5)
+        self.assertEqual(span_data.lookup_weight(5, n, 2), 0.5)
+        self.assertEqual(span_data.lookup_weight(4, n, 2), 1.0)
+
     def test_polytomy_tree(self):
         ts = utility_functions.polytomy_tree_ts()
         span_data = self.verify_weights(ts)

--- a/tests/utility_functions.py
+++ b/tests/utility_functions.py
@@ -432,6 +432,40 @@ def single_tree_ts_with_unary():
     return tskit.load_text(nodes=nodes, edges=edges, strict=False)
 
 
+def two_tree_ts_with_unary_n3():
+    r"""
+    Simple case where we have n = 3 and node 5 is an internal, unary node in the first
+    tree. In the second tree, node t is the root, but still unary.
+             6        .      5
+           /   \      .      |
+          4     5     .      4
+          |     |     .     /  \
+          3     |     .    3    \
+         / \    |     .   / \    \
+       [0] [1] [2]    . [0]  [1] [2]
+    """
+    nodes = io.StringIO("""\
+    id      is_sample   time
+    0       1           0
+    1       1           0
+    2       1           0
+    3       0           1
+    4       0           2
+    5       0           3
+    6       0           4
+    """)
+    edges = io.StringIO("""\
+    left    right   parent  child
+    0       2       3       0,1
+    0       1       5       2
+    0       2       4       3
+    0       1       6       4,5
+    1       2       4       2
+    1       2       5       4
+    """)
+    return tskit.load_text(nodes=nodes, edges=edges, strict=False)
+
+
 def two_tree_mutation_ts():
     r"""
     Simple case where we have n = 3, 2 trees, three mutations.

--- a/tsdate/prior.py
+++ b/tsdate/prior.py
@@ -491,7 +491,7 @@ class SpansBySamples:
                     .format(node, stored_pos[node]))
             if node in self.sample_node_set:
                 return True
-            if util.tree_num_children(prev_tree, node) > 1:
+            if prev_tree.num_children(node) > 1:
                 # This is a coalescent node
                 self._spans[node][num_fixed_at_0_treenodes][n_fixed_at_0] += coverage
             else:
@@ -501,7 +501,7 @@ class SpansBySamples:
                 unary_nodes_above = 0
                 top_node = prev_tree.parent(node)
                 try:  # Find coalescent node above
-                    while util.tree_num_children(prev_tree, top_node) == 1:
+                    while prev_tree.num_children(top_node) == 1:
                         unary_nodes_above += 1
                         top_node = prev_tree.parent(top_node)
                 except ValueError:  # Happens if we have hit the root
@@ -691,7 +691,7 @@ class SpansBySamples:
                     # node is either the root or (more likely) not in
                     # this tree
                 assert tree.num_samples(node) > 0  # No dangling nodes allowed
-                assert util.tree_num_children(tree, node) == 1
+                assert tree.num_children(node) == 1
                 n = node
                 done = False
                 while not done:
@@ -711,7 +711,7 @@ class SpansBySamples:
                                     "Node {} has no fixed descendants".format(n))
                             local_weight = v / self.node_spans[n]
                             self._spans[node][n_tips][k] += tree.span * local_weight / 2
-                    assert util.tree_num_children(tree, node) == 1
+                    assert tree.num_children(node) == 1
                     total_tips = n_tips_per_tree[tree_id]
                     desc_tips = tree.num_samples(node)
                     self._spans[node][total_tips][desc_tips] += tree.span / 2
@@ -734,7 +734,7 @@ class SpansBySamples:
                 tree = next(tree_iter)
             for node in unassigned_nodes:
                 if tree.is_internal(node):
-                    assert util.tree_num_children(tree, node) == 1
+                    assert tree.num_children(node) == 1
                     total_tips = n_tips_per_tree[tree_id]
                     # above, we set the maximum
                     self._spans[node][max_samples][max_samples] += tree.span / 2

--- a/tsdate/util.py
+++ b/tsdate/util.py
@@ -36,13 +36,9 @@ from . import provenance
 logger = logging.getLogger(__name__)
 
 
-def tree_num_children(tree, node):
-    return len(tree.children(node))
-
-
 def get_single_root(tree):
     # TODO - use new 'root_threshold=2' to avoid having to check isolated nodes
-    topological_roots = [r for r in tree.roots if tree_num_children(tree, r) != 0]
+    topological_roots = [r for r in tree.roots if tree.num_children(r) != 0]
     if len(topological_roots) > 1:
         raise ValueError(
             "Invalid tree sequence: tree {} has >1 root".format(tree.index))


### PR DESCRIPTION
Removes our `tree_num_children()` function and use `tskit.Tree.num_children()` instead