### PR TITLE
Changes to sites_time_from_ts

### DIFF
--- a/tests/utility_functions.py
+++ b/tests/utility_functions.py
@@ -890,8 +890,8 @@ def single_tree_ts_2mutations_n3():
     0       1           0
     1       1           0
     2       1           0
-    3       0           1
-    4       0           2
+    3       0           10
+    4       0           20
     """
     )
     edges = io.StringIO(


### PR DESCRIPTION
A fair bit of documentation change, and some other changes as discussed on slack. In particular, the parameter name has changed from mutation_age to node_selection, ignore_multiallelic has been removed, nodes_time now only gets unconstrained times (and the logic is moved into  sites_time_from_ts), and the epsilon value is renamed min_time and set to default to 1 for *all* zero-time sites. This means setting min_time=0 in lots of the unit tests, but I think that's OK.