### PR TITLE
Use Unscaled Time Internally

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -27,13 +27,13 @@ class TestSetCacheDir(unittest.TestCase):
         if os.path.isfile(fn):
             raise AssertionError(f"The file {fn} already exists. Delete before testing")
         with self.assertLogs(level="WARNING") as log:
-            priors_approx10 = ConditionalCoalescentTimes(10)
+            priors_approx10 = ConditionalCoalescentTimes(10, Ne=1)
             assert len(log.output) == 1
             assert "user cache" in log.output[0]
         priors_approx10.add(10)
         # Check we have created the prior file
         assert os.path.isfile(fn)
-        priors_approxNone = ConditionalCoalescentTimes(None)
+        priors_approxNone = ConditionalCoalescentTimes(None, Ne=1)
         priors_approxNone.add(10)
         assert np.allclose(priors_approx10[10], priors_approxNone[10], equal_nan=True)
         # Test when using a bigger n that we're using the precalculated version

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -166,13 +166,14 @@ class TestSimulated:
             recombination_rate=1e-8,
             random_seed=11,
         )
-        priors = tsdate.build_prior_grid(ts, timepoints=10, approximate_priors=None)
+        priors = tsdate.build_prior_grid(
+            ts, Ne=10000, timepoints=10, approximate_priors=None
+        )
         dated_ts = tsdate.date(
-            ts, Ne=10000, mutation_rate=1e-8, priors=priors, probability_space=LIN
+            ts, mutation_rate=1e-8, priors=priors, probability_space=LIN
         )
         maximized_ts = tsdate.date(
             ts,
-            Ne=10000,
             mutation_rate=1e-8,
             priors=priors,
             method="maximization",
@@ -206,9 +207,9 @@ class TestSimulated:
                     continue
             tables.edges.add_row(**attr.asdict(row))
         multiroot_ts = tables.tree_sequence()
-        good_priors = tsdate.build_prior_grid(ts)
+        good_priors = tsdate.build_prior_grid(ts, Ne=1)
         with pytest.raises(ValueError):
-            tsdate.build_prior_grid(multiroot_ts)
+            tsdate.build_prior_grid(multiroot_ts, Ne=1)
         with pytest.raises(ValueError):
             tsdate.date(multiroot_ts, 1, 2)
         with pytest.raises(ValueError):


### PR DESCRIPTION
Remove "Ne" from likelihood calculations and only use it in the prior. Doesn't affect output at all.
Look good @hyanwong ?