### PR TITLE
Fix msprime compatibility

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -166,7 +166,6 @@ class TestEndToEnd:
         t1 = ts1.tables
         t2 = ts2.tables
         assert t1.sites == t2.sites
-        assert t1.mutations == t2.mutations
         # Edges may have been re-ordered, since sortedness requirements specify
         # they are sorted by parent time, and the relative order of
         # (unconnected) parent nodes might have changed due to time inference
@@ -174,11 +173,17 @@ class TestEndToEnd:
         if not times_equal:
             # The dated and undated tree sequences should not have the same node times
             assert not np.array_equal(ts1.tables.nodes.time, ts2.tables.nodes.time)
-            # New tree sequence will have node times in metadata
+            # New tree sequence will have node times in metadata and will no longer have
+            # mutation times
             for column_name in t1.nodes.column_names:
                 if column_name not in ["time", "metadata", "metadata_offset"]:
                     col_t1 = getattr(t1.nodes, column_name)
                     col_t2 = getattr(t2.nodes, column_name)
+                    assert np.array_equal(col_t1, col_t2)
+            for column_name in t1.mutations.column_names:
+                if column_name not in ["time"]:
+                    col_t1 = getattr(t1.mutations, column_name)
+                    col_t2 = getattr(t2.mutations, column_name)
                     assert np.array_equal(col_t1, col_t2)
             # Assert that last provenance shows tree sequence was dated
             assert len(t1.provenances) == len(t2.provenances) - 1

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1103,7 +1103,9 @@ class TestOutsideAlgorithm:
             algo.outside_pass()
 
     def test_normalize_outside(self):
-        ts = msprime.simulate(50, Ne=10000, mutation_rate=1e-8, recombination_rate=1e-8)
+        ts = msprime.simulate(
+            50, Ne=10000, mutation_rate=1e-8, recombination_rate=1e-8, random_seed=12
+        )
         normalize = self.run_outside_algorithm(ts, normalize=True)
         no_normalize = self.run_outside_algorithm(ts, normalize=False)
         assert np.allclose(
@@ -1463,7 +1465,7 @@ class TestPosteriorMeanVar:
 
     def test_node_metadata_simulated_tree(self):
         larger_ts = msprime.simulate(
-            10, mutation_rate=1, recombination_rate=1, length=20
+            10, mutation_rate=1, recombination_rate=1, length=20, random_seed=12
         )
         _, mn_post, _, _, eps, _ = get_dates(larger_ts, 10000)
         dated_ts = date(larger_ts, 10000)
@@ -1618,7 +1620,7 @@ class TestNodeTimes:
 
     def test_node_times(self):
         larger_ts = msprime.simulate(
-            10, mutation_rate=1, recombination_rate=1, length=20
+            10, mutation_rate=1, recombination_rate=1, length=20, random_seed=12
         )
         dated = date(larger_ts, 10000)
         node_ages = nodes_time_unconstrained(dated)
@@ -1747,7 +1749,7 @@ class TestSiteTimes:
 
     def test_sites_time_simulated(self):
         larger_ts = msprime.simulate(
-            10, mutation_rate=1, recombination_rate=1, length=20
+            10, mutation_rate=1, recombination_rate=1, length=20, random_seed=12
         )
         _, mn_post, _, _, _, _ = get_dates(larger_ts, 10000)
         dated = date(larger_ts, 10000)
@@ -1786,6 +1788,7 @@ class TestSampleDataTimes:
             recombination_rate=1e-8,
             Ne=10000,
             length=1e4,
+            random_seed=12,
         )
         samples = tsinfer.formats.SampleData.from_tree_sequence(
             ts, use_individuals_time=True
@@ -1813,6 +1816,7 @@ class TestSampleDataTimes:
             recombination_rate=1e-8,
             Ne=10000,
             length=1e4,
+            random_seed=12,
         )
         samples = tsinfer.formats.SampleData.from_tree_sequence(
             ts, use_sites_time=False
@@ -1834,7 +1838,9 @@ class TestHistoricalExample:
             msprime.Sample(0, 0),
             msprime.Sample(0, 1.0),
         ]
-        return msprime.simulate(samples=samples, mutation_rate=1, length=1e2)
+        return msprime.simulate(
+            samples=samples, mutation_rate=1, length=1e2, random_seed=12
+        )
 
     def test_historical_samples(self):
         ts = self.historical_samples_example()

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -225,6 +225,7 @@ class TestSimulated:
         with pytest.raises(NotImplementedError):
             tsdate.date(ts, 1, 2)
 
+    @pytest.mark.skip("Add when msprime 1.0 is released")
     def test_no_mutation_times(self):
         ts = msprime.simulate(20, Ne=1, mutation_rate=1, random_seed=12)
         assert np.all(ts.tables.mutations.time > 0)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -30,6 +30,7 @@ import msprime
 import numpy as np
 import pytest
 import tsinfer
+import tskit
 import utility_functions
 
 import tsdate
@@ -216,9 +217,15 @@ class TestSimulated:
             msprime.Sample(population=0, time=0),
             msprime.Sample(population=0, time=1.0),
         ]
-        ts = msprime.simulate(samples=samples, Ne=1, mutation_rate=2)
+        ts = msprime.simulate(samples=samples, Ne=1, mutation_rate=2, random_seed=12)
         with pytest.raises(NotImplementedError):
             tsdate.date(ts, 1, 2)
+
+    def test_no_mutation_times(self):
+        ts = msprime.simulate(20, Ne=1, mutation_rate=1, random_seed=12)
+        assert np.all(ts.tables.mutations.time > 0)
+        dated = tsdate.date(ts, 1, 1)
+        assert np.all(dated.tables.mutations.time == tskit.UNKNOWN_TIME)
 
     @pytest.mark.skip("YAN to fix")
     def test_truncated_ts(self):

--- a/tsdate/date.py
+++ b/tsdate/date.py
@@ -955,7 +955,9 @@ def date(
     Take a tree sequence with arbitrary node times and recalculate node times using
     the `tsdate` algorithm. If a mutation_rate is given, the mutation clock is used. The
     recombination clock is unsupported at this time. If neither a mutation_rate nor a
-    recombination_rate is given, a topology-only clock is used.
+    recombination_rate is given, a topology-only clock is used. Times associated with
+    mutations and non-sample nodes in the input tree sequence are not used in inference
+    and will be removed.
 
     :param TreeSequence tree_sequence: The input :class:`tskit.TreeSequence`, treated as
         undated.
@@ -1000,6 +1002,8 @@ def date(
     constrained = constrain_ages_topo(tree_sequence, dates, eps, nds, progress)
     tables = tree_sequence.dump_tables()
     tables.nodes.time = constrained
+    # Remove any times associated with mutations
+    tables.mutations.time = np.full(tree_sequence.num_mutations, tskit.UNKNOWN_TIME)
     tables.sort()
     ts = tables.tree_sequence()
     return provenance.record_provenance(


### PR DESCRIPTION
Bleeding-edge version of `msprime` includes mutation times. When we date a simulated tree sequence, we often set the child node of a mutation to be older than the mutation itself, which causes `tskit` to complain.
Simple fix is to set all mutation times to `tskit.UNKNOWN_TIME` and add a note in the documentation of `tsdate.date()`.
A test that mutation times are removed is skipped until `msprime` 1.0 has been released.