### PR TITLE
fix cache test

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -25,7 +25,8 @@ class TestSetCacheDir(unittest.TestCase):
         # Force approx prior with a tiny n
         fn = ConditionalCoalescentTimes.get_precalc_cache(10)
         if os.path.isfile(fn):
-            raise AssertionError(f"The file {fn} already exists. Delete before testing")
+            # The file already exists. We delete before testing
+            os.remove(fn)
         with self.assertLogs(level="WARNING") as log:
             priors_approx10 = ConditionalCoalescentTimes(10)
             assert len(log.output) == 1


### PR DESCRIPTION
[A test ](https://github.com/tskit-dev/tsdate/blob/2f5821a6ba5ba3a53c91aff0ff680059ac8aab63/tests/test_cache.py#L28) to check the existence of a cache fails if `tests/test_cache.py` is not the first tests module to be run. This changes the test to delete the cache if it is found.
