### PR TITLE
fix race condition tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,5 +54,5 @@ jobs:
       - run:
           name: Run Python tests
           command: |
-              python -m pytest --cov=tsdate  --cov-report=xml --cov-branch -n8 tests
+              python -m pytest --cov=tsdate  --cov-report=xml --cov-branch tests
               python3 -m codecov 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -25,8 +25,7 @@ class TestSetCacheDir(unittest.TestCase):
         # Force approx prior with a tiny n
         fn = ConditionalCoalescentTimes.get_precalc_cache(10)
         if os.path.isfile(fn):
-            # The file already exists. We delete before testing
-            os.remove(fn)
+            raise AssertionError(f"The file {fn} already exists. Delete before testing")
         with self.assertLogs(level="WARNING") as log:
             priors_approx10 = ConditionalCoalescentTimes(10)
             assert len(log.output) == 1

--- a/tsdate/cache.py
+++ b/tsdate/cache.py
@@ -52,7 +52,9 @@ def get_cache_dir():
     precalculated data.
     """
     cache_dir = pathlib.Path(appdirs.user_cache_dir("tsdate", "tsdate"))
-    if not os.path.exists(cache_dir):
-        logger.info(f"Set cache_dir to {cache_dir}")
+    try:
         os.makedirs(cache_dir)
+        logger.info(f"Set cache_dir to {cache_dir}")
+    except OSError:
+        print(f"{cache_dir} already exists")
     return cache_dir


### PR DESCRIPTION
A race condition can cause problems with the tests of the cache. `test_cache.test_cached_prior()` checks that the cache does not exist, while `test_cache.test_cache_dir_exists` fails if the cache dir already exists.
Easy fix is to just remove parallel pytests, I think better solution is to change the way we cache