### PR TITLE
fix race condition, again

### DIFF
--- a/tsdate/cache.py
+++ b/tsdate/cache.py
@@ -52,7 +52,9 @@ def get_cache_dir():
     precalculated data.
     """
     cache_dir = pathlib.Path(appdirs.user_cache_dir("tsdate", "tsdate"))
-    if not os.path.exists(cache_dir):
-        logger.info(f"Set cache_dir to {cache_dir}")
+    try:
         os.makedirs(cache_dir)
+        logger.info(f"Set cache_dir to {cache_dir}")
+    except OSError:
+        logger.info(f"{cache_dir} already exists")
     return cache_dir


### PR DESCRIPTION
A race condition can occur when testing the cache (removing and making the directory), so we use a "try except" block instead of an "if cache exists"