### PR TITLE
Export get_dates (without documentation)

### DIFF
--- a/tsdate/__init__.py
+++ b/tsdate/__init__.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 from .cache import *  # NOQA: F401,F403
 from .core import date  # NOQA: F401
+from .core import get_dates  # NOQA: F401
 from .prior import build_grid as build_prior_grid  # NOQA: F401
 from .provenance import __version__  # NOQA: F401
 from .util import add_sampledata_times  # NOQA: F401


### PR DESCRIPTION
Makes `tsdate.get_dates` available so people can look at the marginal posterior distributions on node time. Won't document it for now.