### PR TITLE
remove typed list and pin numba

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ daiquiri
 msprime
 scipy
 codecov
-numba
+numba==0.53.1
 appdirs
 pre-commit
 pytest

--- a/tsdate/core.py
+++ b/tsdate/core.py
@@ -451,9 +451,9 @@ class LogLikelihoods(Likelihoods):
         res = list()
         i_start = self.row_indices[0][0]
         for i in self.row_indices[0][1:]:
-            res.append(self.logsumexp(numba.typed.List(input_array[i_start:i])))
+            res.append(self.logsumexp(input_array[i_start:i]))
             i_start = i
-        res.append(self.logsumexp(numba.typed.List(input_array[i:])))
+        res.append(self.logsumexp(input_array[i:]))
         return np.array(res)
 
     def rowsum_upper_tri(self, input_array):
@@ -465,9 +465,9 @@ class LogLikelihoods(Likelihoods):
         res = list()
         i_start = self.col_indices[0]
         for i in self.col_indices[1:]:
-            res.append(self.logsumexp(numba.typed.List(input_array[i_start:i])))
+            res.append(self.logsumexp(input_array[i_start:i]))
             i_start = i
-        res.append(self.logsumexp(numba.typed.List(input_array[i:])))
+        res.append(self.logsumexp(input_array[i:]))
         return np.array(res)
 
     def _recombination_loglik(self, edge, fixed=True):


### PR DESCRIPTION
Resolves the performance issue noted in #174 by removing `numba.typed.List` and using reflect lists instead, pinning the numba version to avoid the deprecation issue (for now)