### PR TITLE
Modify tables

### DIFF
--- a/tsdate/core.py
+++ b/tsdate/core.py
@@ -992,9 +992,8 @@ def date(
     # Remove any times associated with mutations
     tables.mutations.time = np.full(tree_sequence.num_mutations, tskit.UNKNOWN_TIME)
     tables.sort()
-    ts = tables.tree_sequence()
-    return provenance.record_provenance(
-        ts,
+    provenance.record_provenance(
+        tables,
         "date",
         Ne=Ne,
         mutation_rate=mutation_rate,
@@ -1002,6 +1001,7 @@ def date(
         progress=progress,
         **kwargs
     )
+    return tables.tree_sequence()
 
 
 def get_dates(

--- a/tsdate/provenance.py
+++ b/tsdate/provenance.py
@@ -81,12 +81,10 @@ def get_provenance_dict(command=None, **kwargs):
     return document
 
 
-def record_provenance(tree_sequence, command=None, **kwargs):
+def record_provenance(tables, command=None, **kwargs):
     """
-    Records the provenance information for this file using the
+    Adds provenance information to this table collection using the
     tskit provenances schema.
     """
     record = get_provenance_dict(command=command, **kwargs)
-    tables = tree_sequence.dump_tables()
     tables.provenances.add_row(record=json.dumps(record))
-    return tables.tree_sequence()


### PR DESCRIPTION
At the moment in tsdate we do a lot of operations where we turn everything into a tree sequence, then back into tables for editing, then back into a tree sequence, etc. It seems simpler and more efficient to keep everything as a table collection while we are simplifying, adding provenance, etc, then exporting the tree sequence right at the end.

This should also make addressing #190 easier.