### PR TITLE
Fix unit test and posteriors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,12 @@
   individuals, populations, or sites, aiming to change the tree sequence tables as
   little as possible.
 
+**Bugfixes**
+
+- The returned posteriors when ``return_posteriors=True`` now return actual
+  probabilities (scaled so that they sum to one) rather than normalised
+  probabilites whose maximum value is one.
+
 --------------------
 [0.1.5] - 2022-06-07
 --------------------

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,5 +1,6 @@
 # MIT License
 #
+# Copyright (c) 2021-23 Tskit Developers
 # Copyright (c) 2020 University of Oxford
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -109,7 +110,7 @@ class TestPrebuilt(unittest.TestCase):
         assert len(posteriors["start_time"]) == len(posteriors["end_time"])
         assert len(posteriors["start_time"]) > 0
         for node in ts.nodes():
-            if not node.is_sample:
+            if not node.is_sample():
                 assert node.id in posteriors
                 assert posteriors[node.id] is None
 
@@ -122,7 +123,7 @@ class TestPrebuilt(unittest.TestCase):
         assert len(posteriors["start_time"]) == len(posteriors["end_time"])
         assert len(posteriors["start_time"]) > 0
         for node in ts.nodes():
-            if not node.is_sample:
+            if not node.is_sample():
                 assert node.id in posteriors
                 assert len(posteriors[node.id]) == len(posteriors["start_time"])
                 assert np.isclose(np.sum(posteriors[node.id]), 1)


### PR DESCRIPTION
Previously we claimed to return posteriors that were probabilities but the testing was broken, so we didn't notice that we weren't scaling the posteriors to add up to one (i.e. they weren't actually probabilities). This fixes the problem, but therefore changes the posteriors that are output. I think this is the right thing to do.