### PR TITLE
Return marginal likelihood from inside algorithm

### DIFF
--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -141,6 +141,16 @@ class TestPrebuilt(unittest.TestCase):
                 assert len(posteriors[node.id]) == len(posteriors["start_time"])
                 assert np.isclose(np.sum(posteriors[node.id]), 1)
 
+    def test_marginal_likelihood(self):
+        ts = utility_functions.two_tree_mutation_ts()
+        _, _, marg_lik = tsdate.date(
+            ts, mutation_rate=None, Ne=1, return_posteriors=True, return_likelihood=True
+        )
+        _, marg_lik_again = tsdate.date(
+            ts, mutation_rate=None, Ne=1, return_likelihood=True
+        )
+        assert marg_lik == marg_lik_again
+
     def test_intervals(self):
         ts = utility_functions.two_tree_ts()
         long_ts = utility_functions.two_tree_ts_extra_length()


### PR DESCRIPTION
- Rationale in #249, first step in addressing #237
- `get_dates` has an extra output at the end, which is the marginal likelihood from the inside pass
- This is returned by `date` if `return_likelihood = True`, in a way that's similar to what is done for posteriors
- The only change to the existing algorithm is to keep the Poisson likelihoods unstandardized. This change doesn't seem to increase the risk of over/underflow, given that inside values are standardized at each node.