### PR TITLE
Gamma-variational inference scheme

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ pre-commit
 pytest
 pytest-xdist
 pytest-cov
+mpmath
+numdifftools

--- a/tests/distribution_functions.py
+++ b/tests/distribution_functions.py
@@ -1,0 +1,541 @@
+# MIT License
+#
+# Copyright (C) 2023 University of Oxford
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+Utility functions to construct distributions used in variational inference,
+for testing purposes
+"""
+import mpmath
+import numpy as np
+import scipy.integrate
+import scipy.special
+
+from tsdate import approx
+from tsdate import hypergeo
+
+
+def kl_divergence(p, logq):
+    """
+    KL(p||q) divergence for fixed p
+    """
+    val, _ = scipy.integrate.quad(lambda x: -p(x) * logq(x), 0, np.inf)
+    return val
+
+
+def conditional_coalescent_pdf(t, n, k):
+    """
+    Evaluate the PDF of the conditional coalescent, using results from Wiuf and
+    Donnelly (1999).
+    """
+
+    def pr_t_bar_a(t, a, n):
+        """
+        Phase-type distribution for sum of waiting times during which
+        there are n, n-1, ..., a+1 ancestors.
+        """
+        lineages = np.arange(n, a, -1)
+        rate = (lineages * (lineages - 1)) / 2
+        weight = []
+        for i in range(len(rate)):
+            weight.append(1)
+            for j in range(len(rate)):
+                if i != j:
+                    weight[-1] *= rate[j] / (rate[j] - rate[i])
+        weight = np.array(weight)
+        val = np.sum(weight * rate * np.exp(-rate * t))
+        return val
+
+    def pr_a(a, n, k):
+        """
+        Hypergeometric-ish distribution for number of ancestors "a" after
+        subsample of size "k" has coalesced in tree of size "n"
+        """
+        return np.exp(
+            np.log(n + 1)
+            + scipy.special.betaln(n - k, k + 2)
+            - np.log(n - a)
+            - scipy.special.betaln(n - a - k + 2, k - 1)
+            - np.log(a + 1)
+            - scipy.special.betaln(a - 1, 3)
+        )
+
+    if n == k:
+        return pr_t_bar_a(t, 1)
+    else:
+        return np.sum(
+            [pr_a(a, n, k) * pr_t_bar_a(t, a, n) for a in range(2, n - k + 2)]
+        )
+
+
+class TiltedGammaDiff:
+    r"""
+    The distribution of the difference of two gamma RVs restricted to the
+    positive reals, tilted by an exponential function.
+
+    Specifically, for p(x; a, b) = b^a/Gamma(a) x^{a-1} e^{-xb}, this is
+
+        p(u; a1, a2, a3, b1, b2, b3) \propto p(u, a3, b3) \times
+            \int_u^inf p(x; a1, b1) p(x - u; a2, b2) dx, u \geq 0
+    """
+
+    @staticmethod
+    def _2F1(a, b, c, z):
+        """
+        log of |Re| for Gaussian hypergeometric function
+        """
+        val = mpmath.log(mpmath.hyp2f1(a, b, c, z))
+        return float(val)
+
+    @staticmethod
+    def _U(a, b, z):
+        """
+        log of |Re| for confluent hypergeometric function of the second kind
+        """
+        val = mpmath.log(mpmath.hyperu(a, b, z))
+        return float(val)
+
+    def __init__(self, shape1, shape2, shape3, rate1, rate2, rate3, reorder=True):
+        assert shape1 > 0 and shape2 > 0 and shape3 > 0
+        assert rate1 >= 0 and rate2 > 0 and rate3 >= 0
+        # for convergence of 2F1, we need rate2 > rate3. Invariant
+        # transformations of 2F1 allow us to switch arguments, with
+        # appropriate rescaling
+        self.reparametrize = rate3 > rate2
+        self.shape1 = shape1
+        self.shape2 = shape2
+        self.shape3 = shape3
+        self.rate1 = rate1
+        self.rate2 = rate2
+        self.rate3 = rate3
+        mu = (1.0 - shape1 - shape2) / 2
+        nu = (shape3 - 1) + (shape1 + shape2) / 2
+        zeta = 1 / 2 - (rate2 - rate3) / (rate1 + rate2)
+        assert zeta > -1 / 2, "Invalid parameters"
+        assert nu + 1 / 2 > abs(mu), "Invalid parameters"
+
+    def pdf(self, x):
+        r"""
+        Probability density function, derived using equation 3.383.4 from
+        Gradshteyn & Ryzhik (2000) "Table of Integrals, Series, and Products"
+
+        That is:
+
+        u^{a3 - 1} e^{(b2 - b3) u} \times
+          \int_u^inf x^{a1-1} (x-u)^{a2-1} e^{-x(b1+b2)} dx =
+        u^{a3 - 1} e^{(b2 - b3) u} (b1+b2)^{-(a1+a2)/2} Gamma(a2) \times
+          u^{(a1+a2)/2-1} e^{-(b1+b2)/2 u} W((a1-a2)/2, (1-a1-a2)/2, (b1+b2)u) =
+        (b1+b2)^{-(a1+a2)/2} Gamma(a2) u^{a3 + (a1+a2)/2 - 2} \times
+          e^{-u(b1+b2)(1/2+(b3 - b2)/(b1 + b2))} \times
+          W((a1-a2)/2, (1-a1-a2)/2, (b1+b2)u)
+
+        s.t. a2 > 0, (b1+b2)u > 0
+
+        Change variables, t = (b1+b2)*u and integrate t using 13.23.4 of DLMF,
+        to find the normalizing constant:
+
+        (b1+b2)^{-(a1+a2)/2} Gamma(a2) (b1+b2)^{-a3-(a1+a2)/2+2} \times
+          \int_0^inf t^{a3+(a1+a2)/2-2} e^{-t (1/2+(b3-b2)/(b1+b2))} \times
+          W((a1-a2)/2, (1-a1-a2)/2, t) 1/(b1+b2) dt =
+        (b1+b2)^{-a1-a2-a3+1} Gamma(a1+a2+a3-1) Beta(a2,a3) \times
+            2F1(a1+a2+a3-1, a3, a3+a2, (b2-b3)/(b1+b2))
+
+        Note that 2F1 is regularized in this equation, e.g. 2F1(a,b;c;z) =
+        2F1(a,b;c;z)/Gamma(c)
+
+        Transform W to U, and use Kummer's transformations:
+
+          W((a1-a2)/2, (1-a1-a2)/2, (b1+b2)u) =
+          exp(-u(b1+b2)/2) (b1+b2)^(1-a1/2-a2/2) \times
+            u^(1-a1/2-a2/2) U(1-a1, 2-a1-a2, (b1+b2)u) =
+          exp(-u(b1+b2)/2) (b1+b2)^(a1/2+a2/2) \times
+            u^(a1/2+a2/2) U(a2, a1+a2, (b1+b2)u)
+
+        so that the kernel becomes,
+
+          Gamma(a2) u^(a3 + a1 + a2 - 2) \times
+            e^(-u(b1+b3)) U(a2, a1+a2, (b1+b2)u)
+
+        In the special case where b1 == b3 == 0 and a1 == a3 == 1, the integral
+        becomes (via 3.382.2 GR2000):
+
+            e^{u b2} \int_u^inf (x-u)^{a2-1} e^{-x b2} dx = Gamma(a2) b2^{-a2}
+
+        e.g. a constant (this should never happen if the edge update order is
+        correct and samples are fixed to the present day, or if a proper prior
+        is used)
+        """
+        assert x >= 0.0, "PDF is only defined for non-negative reals"
+        A = self.shape1 + self.shape2 + self.shape3 - 1
+        B = self.shape3
+        C = self.shape2 + self.shape3
+        S = self.rate2 - self.rate3
+        T = self.rate2 + self.rate1
+        if self.reparametrize:
+            val = (
+                scipy.stats.gamma.logpdf(x, A, scale=1 / (self.rate1 + self.rate3))
+                + self._U(
+                    self.shape2,
+                    self.shape1 + self.shape2,
+                    (self.rate1 + self.rate2) * x,
+                )
+                + scipy.special.loggamma(self.shape2 + self.shape3)
+                - scipy.special.loggamma(self.shape3)
+                - self._2F1(A, C - B, C, S / (S - T))
+            )
+        else:
+            val = (
+                scipy.stats.gamma.logpdf(x, A, scale=1 / (self.rate1 + self.rate3))
+                + self._U(
+                    self.shape2,
+                    self.shape1 + self.shape2,
+                    (self.rate1 + self.rate2) * x,
+                )
+                + scipy.special.loggamma(self.shape2 + self.shape3)
+                - scipy.special.loggamma(self.shape3)
+                + A * np.log(T / (T - S))
+                - self._2F1(A, B, C, S / T)
+            )
+        return np.exp(val)
+
+    def laplace(self, s):
+        """
+        Laplace transform, derived using 13.23.4 in DLMF
+        """
+        # TODO: assert ROC
+        A = self.shape1 + self.shape2 + self.shape3 - 1
+        B = self.shape3
+        C = self.shape2 + self.shape3
+        S = self.rate2 - self.rate3
+        T = self.rate1 + self.rate2
+        if self.reparametrize:
+            val = (
+                -A * np.log(T - S + s)
+                + A * np.log(T - S)
+                + self._2F1(A, C - B, C, (s - S) / (T - S + s))
+                + -self._2F1(A, C - B, C, S / (S - T))
+            )
+        else:
+            val = self._2F1(A, B, C, (S - s) / T) - self._2F1(A, B, C, S / T)
+        return np.exp(val)
+
+    def moments(self):
+        r"""
+        Returns the first two raw moments.
+
+        Derived from differentiating the Laplace transform, and using the relation
+
+            d^n 2F1(A, B, C, z) / dz^n = a_n b_n / c_n 2F1(A + 1, B + 1, C + 1, z)
+
+        where x_n = x (x + 1) \dots (x + n - 1) is the rising factorial and 2F1 is the
+        Gaussian hypergeometric function. See 15.5.2 in DLMF.
+        """
+        A = self.shape1 + self.shape2 + self.shape3 - 1
+        B = self.shape3
+        C = self.shape2 + self.shape3
+        S = self.rate2 - self.rate3
+        T = self.rate1 + self.rate2
+        numer = 0
+        denom = 0
+        moments = []
+        if self.reparametrize:
+            F0 = self._2F1(A, C - B, C, S / (S - T)) - A * np.log(1 - S / T)
+            for i in range(2):
+                numer += np.log(A + i) + np.log(B + i) - np.log(C + i) - np.log(T)
+                denom = (
+                    F0
+                    - self._2F1(A + i + 1, C - B, C + i + 1, S / (S - T))
+                    + (A + i + 1) * np.log(1 - S / T)
+                )
+                moments.append(np.exp(numer - denom))
+        else:
+            F0 = self._2F1(A, B, C, S / T)
+            for i in range(2):
+                numer += np.log(A + i) + np.log(B + i) - np.log(C + i) - np.log(T)
+                denom = F0 - self._2F1(A + i + 1, B + i + 1, C + i + 1, S / T)
+                moments.append(np.exp(numer - denom))
+        return moments[0], moments[1]
+
+    def sufficient_statistics(self):
+        r"""
+        Return E[x], E[x^2], and E[log x].
+
+        To get raw moments use the Laplace transform E[e^{-su}]:
+
+        (b1+b2)^{-a1-a2-a3+1} Gamma(a1+a2+a3-1) Beta(a2,a3) \times
+            2F1(a1+a2+a3-1, a3, a3+a2, (b2-b3-s)/(b1+b2))
+
+        To get log moments use the Mellin transform E[u^s]:
+
+        (b1+b2)^{-a1-a2-a3-s+1} Gamma(a1+a2+a3+s-1) Beta(a2,a3+s) \times
+            2F1(a1+a2+a3+s-1, a3+s, a3+s+a2, (b2-b3)/(b1+b2))
+
+        In both cases: differentiate wrt s, evaluate at zero, and normalize
+        """
+        A = self.shape1 + self.shape2 + self.shape3 - 1
+        B = self.shape3
+        C = self.shape2 + self.shape3
+        S = self.rate2 - self.rate3
+        T = self.rate1 + self.rate2
+        if self.reparametrize:
+            # underflow protection is used, so the actual derivatives are
+            # np.exp(F) * dF_dz, etc.
+            F, dF_da, _, dF_dc, dF_dz, d2F_dz2 = hypergeo._hyp2f1_series(
+                A,
+                C - B,
+                C,
+                S / (S - T),
+            )
+            logconst = (
+                F
+                + scipy.special.betaln(self.shape2, self.shape3)
+                + scipy.special.loggamma(A)
+                - A * np.log(T - S)
+            )
+            x = -dF_dz * T / (S - T) ** 2 - A / (S - T)
+            xsq = (
+                d2F_dz2 * T**2 / (S - T) ** 4
+                + A * (A + 1) / (T - S) ** 2
+                + 2 * dF_dz * (1 + A) * T / (S - T) ** (3)
+            )
+            logx = (
+                (dF_da + dF_dc)
+                + -np.log(1 - S / T)
+                + scipy.special.digamma(A)
+                + scipy.special.digamma(B)
+                - scipy.special.digamma(C)
+                - np.log(T)
+            )
+        else:
+            F, dF_da, dF_db, dF_dc, dF_dz, d2F_dz2 = hypergeo._hyp2f1_series(
+                A,
+                B,
+                C,
+                S / T,
+            )
+            logconst = (
+                F
+                + scipy.special.betaln(self.shape2, self.shape3)
+                + scipy.special.loggamma(A)
+                - A * np.log(T)
+            )
+            x = dF_dz / T
+            xsq = d2F_dz2 / T**2
+            logx = (
+                (dF_da + dF_db + dF_dc)
+                + scipy.special.digamma(A)
+                + scipy.special.digamma(B)
+                - scipy.special.digamma(C)
+                - np.log(T)
+            )
+        return logconst, x, xsq, logx
+
+    def to_gamma(self, minimize_kl=True):
+        """
+        Return the shape and rate parameters of a gamma distribution with the
+        same expected sufficient statistics (if ``minimize_kl`` is ``True``), and
+        otherwise one with the same mean and variance.
+        """
+        logconst, x, xsq, logx = self.sufficient_statistics()
+        if minimize_kl:
+            _, xlogx, _ = approx.approximate_log_moments(x, xsq)
+            alpha, beta = approx.approximate_gamma_kl(x, logx, xlogx)
+        else:
+            alpha, beta = approx.approximate_gamma_mom(x, xsq)
+        return logconst, alpha, beta
+
+
+class TiltedGammaSum:
+    r"""
+    The distribution of the sum of two gamma RVs, tilted by an exponential function.
+
+    Specifically, for p(x; a, b) = b^a/Gamma(a) x^{a-1} e^{-xb}, this is
+
+        p(u; a1, a2, a3, b1, b2, b3) \propto p(u; a3, b3) \times
+            \int_0^u p(x; a1, b1) p(u - x; a2, b2) dx, u \geq 0
+    """
+
+    @staticmethod
+    def _2F1(a, b, c, z):
+        """
+        log of |Re| for Gaussian hypergeometric function
+        """
+        val = mpmath.log(mpmath.hyp2f1(a, b, c, z))
+        return float(val)
+
+    @staticmethod
+    def _M(a, b, x):
+        """
+        log of |Re| for confluent hypergeometric function (aka 1F1)
+        """
+        val = mpmath.log(mpmath.hyp1f1(a, b, x))
+        return float(val)
+
+    def __init__(self, shape1, shape2, shape3, rate1, rate2, rate3):
+        assert shape1 > 0 and shape2 > 0 and shape3 > 0
+        assert rate1 >= 0 and rate2 > 0 and rate3 >= 0
+        # for numeric stability of hypergeometric we need rate2 > rate1
+        # as this is a convolution, the order of (1) and (2) don't matter
+        self.reparametrize = rate1 > rate2
+        self.shape1 = shape2 if self.reparametrize else shape1
+        self.shape2 = shape1 if self.reparametrize else shape2
+        self.shape3 = shape3
+        self.rate1 = rate2 if self.reparametrize else rate1
+        self.rate2 = rate1 if self.reparametrize else rate2
+        self.rate3 = rate3
+        assert shape1 + shape2 + shape3 - 1 > 0, "Invalid parameters"
+        assert rate3 + rate2 > max(0, rate2 - rate1), "Invalid parameters"
+
+    def pdf(self, x):
+        r"""
+        Probability density function, derived using equation 3.383.1 from
+        Gradshteyn & Ryzhik (2000) "Table of Integrals, Series, and Products"
+
+        u^{a3-1} e^{-u b3} \times
+            \int_0^u x^{a1-1} (u-x)^{a2-1} e^{-x b1} e^{-(u-x) b2} dx =
+        u^{a3-1} e^{-u (b2 + b3)} \times
+            \int_0^u x^{a1-1} (u-x)^{a2-1} e^{x (b2-b1)} dx =
+        Beta(a2, a1) u^{a1 + a2 + a3 - 2} e^{-u (b2+b3)} M(a1, a1+a2, (b2-b1) u)
+
+        s.t. a1 > 0, a2 > 0
+
+        Then integrate u using 13.10.3 of DLMF -- note that this equation is
+        regularized, so that we have M(a,c,kt)/Gamma(c) and
+        2F1(a,b;c;z)/Gamma(c)
+
+        \int_0^\infty e^{-u (b2+b3)} u^{a1+a2+a3-2} M(a1, a1+a2, (b2-b1) u) du =
+            Gamma(a1+a2+a3-1) (b2+b3)^{-a1-a2-a3+1} \times
+              2F1(a1, a1+a2+a3-1, a1+a2, (b2-b1)/(b2+b3))
+
+        s.t. a1+a2 > 1
+        s.t. b2 > max(b2-b1, 0)
+
+        In the special case where b1 == b3 == 0 and a1 == a3 == 1, the integrals
+        become (via 3.382.1 in GR2000):
+
+        e^{-u b2} \int_0^u (u-x)^{a2-1} e^{x b2} dx = b2^(-a2) gamma(a2, b2 u)
+
+        which is improper (this special case should never happen if edge order
+        is correct or priors are proper)
+        """
+        assert x >= 0.0, "PDF is only defined for non-negative reals"
+        A = self.shape1
+        B = self.shape1 + self.shape2 + self.shape3 - 1
+        C = self.shape1 + self.shape2
+        T = self.rate2 - self.rate1
+        S = self.rate2 + self.rate3
+        val = (
+            scipy.stats.gamma.logpdf(x, B, scale=1 / S)
+            + self._M(self.shape1, self.shape1 + self.shape2, T * x)
+            - self._2F1(A, B, C, T / S)
+        )
+        return np.exp(val)
+
+    def laplace(self, s):
+        """
+        Laplace transform, derived using 13.10.3 in DLMF
+        """
+        # TODO: assert ROC
+        A = self.shape1
+        B = self.shape1 + self.shape2 + self.shape3 - 1
+        C = self.shape1 + self.shape2
+        T = self.rate2 - self.rate1
+        S = self.rate2 + self.rate3
+        val = (
+            self._2F1(A, B, C, T / (S + s))
+            - self._2F1(A, B, C, T / S)
+            + B * (np.log(S) - np.log(S + s))
+        )
+        return np.exp(val)
+
+    def moments(self):
+        r"""
+        First two raw moments, from differentiating the Laplace transform
+        """
+        A = self.shape1
+        B = self.shape1 + self.shape2 + self.shape3 - 1
+        C = self.shape1 + self.shape2
+        T = self.rate2 - self.rate1
+        S = self.rate2 + self.rate3
+        F0 = self._2F1(A, B, C, T / S)
+        Z1 = np.log(A) + np.log(B) - np.log(C)
+        F1 = self._2F1(A + 1, B + 1, C + 1, T / S)
+        Z2 = Z1 + np.log(A + 1) + np.log(B + 1) - np.log(C + 1)
+        F2 = self._2F1(A + 2, B + 2, C + 2, T / S)
+        x = np.exp(F1 - F0 + Z1) * T / S**2 + B / S
+        xsq = (
+            B * (B + 1) / S**2
+            + 2 * (B + 1) * T / S**3 * np.exp(Z1 + F1 - F0)
+            + T**2 / S**4 * np.exp(Z2 + F2 - F0)
+        )
+        return x, xsq
+
+    def sufficient_statistics(self):
+        r"""
+        Return E[x], E[x^2], and E[log x].
+
+        To get raw moments use the Laplace transform E[e^{-su}]:
+
+        Gamma(a1+a2+a3-1) (b2+b3+s)^{-a1-a2-a3+1} \times
+          2F1(a1, a1+a2+a3-1, a1+a2, (b2-b1)/(b2+b3+s))
+
+        To get log moments use the Mellin transform E[u^s]:
+
+        Gamma(a1+a2+a3+s-1) (b2+b3)^{-a1-a2-a3+s+1} \times
+          2F1(a1, a1+a2+a3+s-1, a1+a2, (b2-b1)/(b2+b3))
+
+        In both cases: differentiate wrt s, evaluate at zero, and normalize
+        """
+        A = self.shape1
+        B = self.shape1 + self.shape2 + self.shape3 - 1
+        C = self.shape1 + self.shape2
+        T = self.rate2 - self.rate1
+        S = self.rate2 + self.rate3
+        # underflow protection is used, so the actual derivatives are
+        # np.exp(F) * dF_dz, etc.
+        F, _, dF_db, _, dF_dz, d2F_dz2 = hypergeo._hyp2f1_series(A, B, C, T / S)
+        logconst = (
+            F
+            + scipy.special.loggamma(B)
+            - B * np.log(S)
+            + scipy.special.betaln(self.shape1, self.shape2)
+        )
+        x = dF_dz * T / S**2 + B / S
+        xsq = (
+            d2F_dz2 * T**2 / S**4
+            + B * (B + 1) / S**2
+            + 2 * dF_dz * (1 + B) * T / S**3
+        )
+        logx = dF_db + scipy.special.digamma(B) - np.log(S)
+        return logconst, x, xsq, logx
+
+    def to_gamma(self, minimize_kl=True):
+        """
+        Return the shape and rate parameters of a gamma distribution with the
+        same expected sufficient statistics (if ``minimize_kl`` is ``True``), and
+        otherwise one with the same mean and variance.
+        """
+        logconst, x, xsq, logx = self.sufficient_statistics()
+        if minimize_kl:
+            _, xlogx, _ = approx.approximate_log_moments(x, xsq)
+            alpha, beta = approx.approximate_gamma_kl(x, logx, xlogx)
+        else:
+            alpha, beta = approx.approximate_gamma_mom(x, xsq)
+        return logconst, alpha, beta

--- a/tests/distribution_functions.py
+++ b/tests/distribution_functions.py
@@ -1,5 +1,6 @@
 # MIT License
 #
+# Copyright (C) 2023 Tskit Developers
 # Copyright (C) 2023 University of Oxford
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -215,27 +216,6 @@ class TiltedGammaDiff:
             )
         return np.exp(val)
 
-    def laplace(self, s):
-        """
-        Laplace transform, derived using 13.23.4 in DLMF
-        """
-        # TODO: assert ROC
-        A = self.shape1 + self.shape2 + self.shape3 - 1
-        B = self.shape3
-        C = self.shape2 + self.shape3
-        S = self.rate2 - self.rate3
-        T = self.rate1 + self.rate2
-        if self.reparametrize:
-            val = (
-                -A * np.log(T - S + s)
-                + A * np.log(T - S)
-                + self._2F1(A, C - B, C, (s - S) / (T - S + s))
-                + -self._2F1(A, C - B, C, S / (S - T))
-            )
-        else:
-            val = self._2F1(A, B, C, (S - s) / T) - self._2F1(A, B, C, S / T)
-        return np.exp(val)
-
     def moments(self):
         r"""
         Returns the first two raw moments.
@@ -445,23 +425,6 @@ class TiltedGammaSum:
             scipy.stats.gamma.logpdf(x, B, scale=1 / S)
             + self._M(self.shape1, self.shape1 + self.shape2, T * x)
             - self._2F1(A, B, C, T / S)
-        )
-        return np.exp(val)
-
-    def laplace(self, s):
-        """
-        Laplace transform, derived using 13.10.3 in DLMF
-        """
-        # TODO: assert ROC
-        A = self.shape1
-        B = self.shape1 + self.shape2 + self.shape3 - 1
-        C = self.shape1 + self.shape2
-        T = self.rate2 - self.rate1
-        S = self.rate2 + self.rate3
-        val = (
-            self._2F1(A, B, C, T / (S + s))
-            - self._2F1(A, B, C, T / S)
-            + B * (np.log(S) - np.log(S + s))
         )
         return np.exp(val)
 

--- a/tests/test_approximations.py
+++ b/tests/test_approximations.py
@@ -1,0 +1,188 @@
+# MIT License
+#
+# Copyright (c) 2021-23 Tskit Developers
+# Copyright (c) 2020-21 University of Oxford
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+Test cases for the gamma-variational approximations in tsdate
+"""
+import numpy as np
+import pytest
+import scipy.integrate
+import scipy.stats
+from distribution_functions import conditional_coalescent_pdf
+from distribution_functions import kl_divergence
+
+from tsdate import approx
+from tsdate import hypergeo
+from tsdate import prior
+
+_gamma_trio_test_cases = [  # [shape1, rate1, shape2, rate2, muts, rate]
+    [10.541, 0.0005, 10.552, 0.005, 1.0, 0.0151],
+    [10.541, 0.0065, 10.552, 0.005, 1.0, 0.0101],
+    [10.541, 0.0065, 10.552, 0.022, 1.0, 0.0051],
+    [10.541, 0.0265, 10.552, 0.022, 1.0, 0.0051],
+    [4, 4, 4, 4, 4, 4],
+]
+
+
+@pytest.mark.parametrize("pars", _gamma_trio_test_cases)
+class TestPosteriorMomentMatching:
+    """
+    Test approximation of marginal pairwise joint distributions by a gamma via
+    moment matching of sufficient statistics
+    """
+
+    @staticmethod
+    def pdf(t_i, t_j, a_i, b_i, a_j, b_j, y, mu):
+        """
+        Target joint (pair) distribution, proportional to the parent/child
+        marginals (gamma) and a Poisson mutation likelihood
+        """
+        if t_i < t_j:
+            return 0.0
+        else:
+            return (
+                t_i ** (a_i - 1)
+                * np.exp(-t_i * b_i)
+                * t_j ** (a_j - 1)
+                * np.exp(-t_j * b_j)
+                * (t_i - t_j) ** y
+                * np.exp(-(t_i - t_j) * mu)
+            )
+
+    def test_sufficient_statistics(self, pars):
+        print((pars[5] - pars[3]) / (pars[1] + pars[5]))
+        logconst, t_i, ln_t_i, t_j, ln_t_j = approx.sufficient_statistics(*pars)
+        ck_normconst = scipy.integrate.dblquad(
+            lambda ti, tj: self.pdf(ti, tj, *pars), 0, np.inf, lambda tj: tj, np.inf
+        )[0]
+        assert np.isclose(logconst, np.log(ck_normconst), rtol=1e-3)
+        ck_t_i = scipy.integrate.dblquad(
+            lambda ti, tj: ti * self.pdf(ti, tj, *pars) / ck_normconst,
+            0,
+            np.inf,
+            lambda tj: tj,
+            np.inf,
+        )[0]
+        assert np.isclose(t_i, ck_t_i, rtol=1e-3)
+        ck_t_j = scipy.integrate.dblquad(
+            lambda ti, tj: tj * self.pdf(ti, tj, *pars) / ck_normconst,
+            0,
+            np.inf,
+            lambda tj: tj,
+            np.inf,
+        )[0]
+        assert np.isclose(t_j, ck_t_j, rtol=1e-3)
+        ck_ln_t_i = scipy.integrate.dblquad(
+            lambda ti, tj: np.log(ti) * self.pdf(ti, tj, *pars) / ck_normconst,
+            0,
+            np.inf,
+            lambda tj: tj,
+            np.inf,
+        )[0]
+        assert np.isclose(ln_t_i, ck_ln_t_i, rtol=1e-3)
+        ck_ln_t_j = scipy.integrate.dblquad(
+            lambda ti, tj: np.log(tj) * self.pdf(ti, tj, *pars) / ck_normconst,
+            0,
+            np.inf,
+            lambda tj: tj,
+            np.inf,
+        )[0]
+        assert np.isclose(ln_t_j, ck_ln_t_j, rtol=1e-3)
+
+    def test_approximate_gamma(self, pars):
+        _, t_i, ln_t_i, t_j, ln_t_j = approx.sufficient_statistics(*pars)
+        alpha_i, beta_i = approx.approximate_gamma_kl(t_i, ln_t_i)
+        alpha_j, beta_j = approx.approximate_gamma_kl(t_j, ln_t_j)
+        ck_t_i = alpha_i / beta_i
+        assert np.isclose(t_i, ck_t_i)
+        ck_t_j = alpha_j / beta_j
+        assert np.isclose(t_j, ck_t_j)
+        ck_ln_t_i = hypergeo._digamma(alpha_i) - np.log(beta_i)
+        assert np.isclose(ln_t_i, ck_ln_t_i)
+        ck_ln_t_j = hypergeo._digamma(alpha_j) - np.log(beta_j)
+        assert np.isclose(ln_t_j, ck_ln_t_j)
+
+
+class TestPriorMomentMatching:
+    """
+    Test approximation of the conditional coalescent prior via
+    moment matching to a gamma distribution
+    """
+
+    n = 10
+    priors = prior.ConditionalCoalescentTimes(False)
+    priors.add(n)
+
+    @pytest.mark.parametrize("k", np.arange(2, 10))
+    def test_conditional_coalescent_pdf(self, k):
+        """
+        Check that the utility function matches the implementation in
+        `tsdate.prior`
+        """
+        mean, _ = scipy.integrate.quad(
+            lambda x: x * conditional_coalescent_pdf(x, self.n, k), 0, np.inf
+        )
+        var, _ = scipy.integrate.quad(
+            lambda x: x**2 * conditional_coalescent_pdf(x, self.n, k), 0, np.inf
+        )
+        var -= mean**2
+        mean_column = prior.PriorParams.field_index("mean")
+        var_column = prior.PriorParams.field_index("var")
+        assert np.isclose(mean, self.priors[self.n][k][mean_column])
+        assert np.isclose(var, self.priors[self.n][k][var_column])
+
+    @pytest.mark.parametrize("k", np.arange(2, 10))
+    def test_approximate_gamma(self, k):
+        """
+        Test that matching gamma to Taylor-series-approximated sufficient
+        statistics will result in lower KL divergence than matching to
+        mean/variance
+        """
+        mean_column = prior.PriorParams.field_index("mean")
+        var_column = prior.PriorParams.field_index("var")
+        x = self.priors[self.n][k][mean_column]
+        xvar = self.priors[self.n][k][var_column]
+        # match mean/variance
+        alpha_0, beta_0 = approx.approximate_gamma_mom(x, xvar)
+        ck_x = alpha_0 / beta_0
+        ck_xvar = alpha_0 / beta_0**2
+        assert np.isclose(x, ck_x)
+        assert np.isclose(xvar, ck_xvar)
+        # match approximate sufficient statistics
+        logx, _, _ = approx.approximate_log_moments(x, xvar)
+        alpha_1, beta_1 = approx.approximate_gamma_kl(x, logx)
+        ck_x = alpha_1 / beta_1
+        ck_logx = hypergeo._digamma(alpha_1) - np.log(beta_1)
+        assert np.isclose(x, ck_x)
+        assert np.isclose(logx, ck_logx)
+        # compare KL divergence between strategies
+        kl_0 = kl_divergence(
+            lambda x: conditional_coalescent_pdf(x, self.n, k),
+            lambda x: scipy.stats.gamma.logpdf(x, alpha_0, scale=1 / beta_0),
+        )
+        kl_1 = kl_divergence(
+            lambda x: conditional_coalescent_pdf(x, self.n, k),
+            lambda x: scipy.stats.gamma.logpdf(x, alpha_1, scale=1 / beta_1),
+        )
+        print(kl_1, kl_0)
+        assert kl_1 < kl_0

--- a/tests/test_approximations.py
+++ b/tests/test_approximations.py
@@ -44,6 +44,18 @@ _gamma_trio_test_cases = [  # [shape1, rate1, shape2, rate2, muts, rate]
 ]
 
 
+def approximate_gamma_mom(mean, variance):
+    """
+    Use the method of moments to approximate a distribution with a gamma of the
+    same mean and variance
+    """
+    assert mean > 0
+    assert variance > 0
+    alpha = mean**2 / variance
+    beta = mean / variance
+    return alpha, beta
+
+
 @pytest.mark.parametrize("pars", _gamma_trio_test_cases)
 class TestPosteriorMomentMatching:
     """

--- a/tests/test_approximations.py
+++ b/tests/test_approximations.py
@@ -70,7 +70,6 @@ class TestPosteriorMomentMatching:
             )
 
     def test_sufficient_statistics(self, pars):
-        print((pars[5] - pars[3]) / (pars[1] + pars[5]))
         logconst, t_i, ln_t_i, t_j, ln_t_j = approx.sufficient_statistics(*pars)
         ck_normconst = scipy.integrate.dblquad(
             lambda ti, tj: self.pdf(ti, tj, *pars), 0, np.inf, lambda tj: tj, np.inf
@@ -184,5 +183,4 @@ class TestPriorMomentMatching:
             lambda x: conditional_coalescent_pdf(x, self.n, k),
             lambda x: scipy.stats.gamma.logpdf(x, alpha_1, scale=1 / beta_1),
         )
-        print(kl_1, kl_0)
         assert kl_1 < kl_0

--- a/tests/test_approximations.py
+++ b/tests/test_approximations.py
@@ -174,7 +174,7 @@ class TestPriorMomentMatching:
         x = self.priors[self.n][k][mean_column]
         xvar = self.priors[self.n][k][var_column]
         # match mean/variance
-        alpha_0, beta_0 = approx.approximate_gamma_mom(x, xvar)
+        alpha_0, beta_0 = approximate_gamma_mom(x, xvar)
         ck_x = alpha_0 / beta_0
         ck_xvar = alpha_0 / beta_0**2
         assert np.isclose(x, ck_x)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -2087,11 +2087,6 @@ class TestPopulationSizeHistory:
         analy_va = scipy.stats.gamma.var(shape, scale=1 / rate)
         assert np.isclose(numer_mn, analy_mn)
         assert np.isclose(numer_va, analy_va)
-        shape, rate = demography.to_gamma_depr(shape=alpha, rate=beta)
-        analy_mn = scipy.stats.gamma.mean(shape, scale=1 / rate)
-        analy_va = scipy.stats.gamma.var(shape, scale=1 / rate)
-        assert np.isclose(numer_mn, analy_mn)
-        assert np.isclose(numer_va, analy_va)
 
     def test_bad_arguments(self):
         with pytest.raises(ValueError, match="a numpy array"):

--- a/tests/test_hypergeo.py
+++ b/tests/test_hypergeo.py
@@ -1,0 +1,248 @@
+# MIT License
+#
+# Copyright (c) 2021-23 Tskit Developers
+# Copyright (c) 2020-21 University of Oxford
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+Test cases for numba-fied hypergeometric functions
+"""
+import itertools
+
+import mpmath
+import numdifftools as nd
+import numpy as np
+import pytest
+
+from tsdate import hypergeo
+
+
+@pytest.mark.parametrize("x", [1e-10, 1e-6, 1e-2, 1e1, 1e2, 1e3, 1e5, 1e10])
+class TestPolygamma:
+    """
+    Test numba-fied gamma functions
+    """
+
+    def test_gammaln(self, x):
+        assert np.isclose(hypergeo._gammaln(x), float(mpmath.loggamma(x)))
+
+    def test_digamma(self, x):
+        assert np.isclose(hypergeo._digamma(x), float(mpmath.psi(0, x)))
+
+    def test_trigamma(self, x):
+        assert np.isclose(hypergeo._trigamma(x), float(mpmath.psi(1, x)))
+
+    def test_betaln(self, x):
+        assert np.isclose(
+            hypergeo._betaln(x, 2 * x), float(mpmath.log(mpmath.beta(x, 2 * x)))
+        )
+
+
+@pytest.mark.parametrize(
+    "pars",
+    list(
+        itertools.product(
+            [0.8, 20.0, 200.0],
+            [1.9, 90.3, 900.3],
+            [1.6, 30.7, 300.7],
+            [0.0, 0.1, 0.45],
+        )
+    ),
+)
+class TestTaylorSeries:
+    """
+    Test Taylor series expansions of 2F1
+    """
+
+    @staticmethod
+    def _2f1_validate(a, b, c, z, offset=1.0):
+        val = mpmath.re(mpmath.hyp2f1(a, b, c, z))
+        return val / offset
+
+    @staticmethod
+    def _2f1_grad_validate(a, b, c, z, offset=1.0):
+        p = [a, b, c, z]
+        grad = nd.Gradient(
+            lambda x: float(TestTaylorSeries._2f1_validate(*x, offset=offset)),
+            step=1e-7,
+            richardson_terms=4,
+        )
+        return grad(p)
+
+    def test_2f1(self, pars):
+        f, s, *_ = hypergeo._hyp2f1_taylor_series(*pars)
+        check = self._2f1_validate(*pars)
+        assert s == mpmath.sign(check)
+        print(f, mpmath.log(mpmath.fabs(check)))
+        assert np.isclose(f, float(mpmath.log(mpmath.fabs(check))))
+
+    def test_2f1_grad(self, pars):
+        _, _, *grad = hypergeo._hyp2f1_taylor_series(*pars)
+        grad = grad[:-1]
+        offset = self._2f1_validate(*pars)
+        check = self._2f1_grad_validate(*pars, offset=offset)
+        print(grad, check)
+        assert np.allclose(grad, check)
+
+
+@pytest.mark.parametrize(
+    "pars",
+    list(
+        itertools.product(
+            [0.8, 20.3, 200.2],
+            [0.0, 1.0, 10.0, 51.0],
+            [1.6, 30.5, 300.7],
+            [1.1, 1.5, 1.9],
+        )
+    ),
+)
+class TestRecurrence:
+    """
+    Test recurrence for 2F1 when one parameter is a negative integer
+    """
+
+    @staticmethod
+    def _transform_pars(a, b, c, z):
+        return a, b, c + a, z
+
+    @staticmethod
+    def _2f1_validate(a, b, c, z, offset=1.0):
+        val = mpmath.re(mpmath.hyp2f1(a, -b, c, z))
+        return val / offset
+
+    @staticmethod
+    def _2f1_grad_validate(a, b, c, z, offset=1.0):
+        p = [a, b, c, z]
+        grad = nd.Gradient(
+            lambda x: float(TestRecurrence._2f1_validate(*x, offset=offset)),
+            step=1e-6,
+            richardson_terms=4,
+        )
+        return grad(p)
+
+    def test_2f1(self, pars):
+        pars = self._transform_pars(*pars)
+        f, s, *_ = hypergeo._hyp2f1_recurrence(*pars)
+        check = self._2f1_validate(*pars)
+        assert s == mpmath.sign(check)
+        print(f, mpmath.log(mpmath.fabs(check)))
+        assert np.isclose(f, float(mpmath.log(mpmath.fabs(check))))
+
+    def test_2f1_grad(self, pars):
+        pars = self._transform_pars(*pars)
+        _, _, *grad = hypergeo._hyp2f1_recurrence(*pars)
+        grad = grad[:-1]
+        offset = self._2f1_validate(*pars)
+        check = self._2f1_grad_validate(*pars, offset=offset)
+        check[1] = 0.0  # integer parameter has no gradient
+        print(grad, check)
+        assert np.allclose(grad, check)
+
+
+@pytest.mark.parametrize(
+    "pars",
+    list(
+        itertools.product(
+            [-130.1, 20.0, 200.0],
+            [-20.2, 90.3, 900.3],
+            [-1.6, 30.7, 300.7],
+            [-3.0, -0.5, 0.0, 0.1, 0.9],
+        )
+    ),
+)
+class TestCheckValid2F1:
+    """
+    Test the check for 2F1 series convergence, that plugs derivatives into the
+    differential equation that defines 2F1
+    """
+
+    @staticmethod
+    def _2f1(a, b, c, z):
+        val = mpmath.re(mpmath.hyp2f1(a, b, c, z))
+        dz = a * b / c * mpmath.re(mpmath.hyp2f1(a + 1, b + 1, c + 1, z))
+        d2z = (
+            a
+            * b
+            / c
+            * (a + 1)
+            * (b + 1)
+            / (c + 1)
+            * mpmath.re(mpmath.hyp2f1(a + 2, b + 2, c + 2, z))
+        )
+        return float(dz / val), float(d2z / val)
+
+    def test_is_valid_2f1(self, pars):
+        dz, d2z = self._2f1(*pars)
+        assert hypergeo._is_valid_2f1(dz, d2z, *pars)
+        # perturb solution to differential equation
+        dz *= 1 + 1e-3
+        d2z *= 1 - 1e-3
+        assert not hypergeo._is_valid_2f1(dz, d2z, *pars)
+
+
+@pytest.mark.parametrize("muts", [0.0, 1.0, 5.0, 10.0])
+@pytest.mark.parametrize(
+    "hyp2f1_func, pars",
+    [
+        (hypergeo._hyp2f1_dlmf1521, [1.4, 0.018, 2.34, 2.3e-05, 0.0, 0.0395]),
+        (hypergeo._hyp2f1_dlmf1581, [1.4, 0.018, 20.3, 0.04, 0.0, 2.3e-05]),
+        (hypergeo._hyp2f1_dlmf1583, [5.4, 0.018, 10.34, 0.04, 0.0, 2.3e-05]),
+    ],
+)
+class TestTransforms:
+    """
+    Test numerically stable transformations of hypergeometric functions
+    """
+
+    @staticmethod
+    def _2f1_validate(a_i, b_i, a_j, b_j, y, mu, offset=1.0):
+        A = a_j
+        B = a_i + a_j + y
+        C = a_j + y + 1
+        z = (mu - b_j) / (mu + b_i)
+        val = mpmath.re(mpmath.hyp2f1(A, B, C, z, maxterms=1e6))
+        return val / offset
+
+    @staticmethod
+    def _2f1_grad_validate(a_i, b_i, a_j, b_j, y, mu, offset=1.0):
+        p = [a_i, b_i, a_j, b_j]
+        grad = nd.Gradient(
+            lambda x: float(TestTransforms._2f1_validate(*x, y, mu, offset=offset)),
+            step=1e-6,
+            richardson_terms=4,
+        )
+        return grad(p)
+
+    def test_2f1(self, muts, hyp2f1_func, pars):
+        pars[4] = muts
+        f, s, *_ = hyp2f1_func(*pars)
+        assert s > 0
+        check = float(mpmath.log(self._2f1_validate(*pars)))
+        print(f, check)
+        assert np.isclose(f, check)
+
+    def test_2f1_grad(self, muts, hyp2f1_func, pars):
+        pars[4] = muts
+        _, s, *grad = hyp2f1_func(*pars)
+        assert s > 0
+        offset = self._2f1_validate(*pars)
+        check = self._2f1_grad_validate(*pars, offset=offset)
+        print(grad, check)
+        assert np.allclose(grad, check)

--- a/tests/test_hypergeo.py
+++ b/tests/test_hypergeo.py
@@ -90,7 +90,6 @@ class TestTaylorSeries:
         f, s, *_ = hypergeo._hyp2f1_taylor_series(*pars)
         check = self._2f1_validate(*pars)
         assert s == mpmath.sign(check)
-        print(f, mpmath.log(mpmath.fabs(check)))
         assert np.isclose(f, float(mpmath.log(mpmath.fabs(check))))
 
     def test_2f1_grad(self, pars):
@@ -98,7 +97,6 @@ class TestTaylorSeries:
         grad = grad[:-1]
         offset = self._2f1_validate(*pars)
         check = self._2f1_grad_validate(*pars, offset=offset)
-        print(grad, check)
         assert np.allclose(grad, check)
 
 
@@ -142,7 +140,6 @@ class TestRecurrence:
         f, s, *_ = hypergeo._hyp2f1_recurrence(*pars)
         check = self._2f1_validate(*pars)
         assert s == mpmath.sign(check)
-        print(f, mpmath.log(mpmath.fabs(check)))
         assert np.isclose(f, float(mpmath.log(mpmath.fabs(check))))
 
     def test_2f1_grad(self, pars):
@@ -152,7 +149,6 @@ class TestRecurrence:
         offset = self._2f1_validate(*pars)
         check = self._2f1_grad_validate(*pars, offset=offset)
         check[1] = 0.0  # integer parameter has no gradient
-        print(grad, check)
         assert np.allclose(grad, check)
 
 
@@ -235,7 +231,6 @@ class TestTransforms:
         f, s, *_ = hyp2f1_func(*pars)
         assert s > 0
         check = float(mpmath.log(self._2f1_validate(*pars)))
-        print(f, check)
         assert np.isclose(f, check)
 
     def test_2f1_grad(self, muts, hyp2f1_func, pars):
@@ -244,5 +239,4 @@ class TestTransforms:
         assert s > 0
         offset = self._2f1_validate(*pars)
         check = self._2f1_grad_validate(*pars, offset=offset)
-        print(grad, check)
         assert np.allclose(grad, check)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -372,3 +372,41 @@ class TestInferred:
             assert all(
                 [a == b for a, b in zip(ts.haplotypes(), io_dated_ts.haplotypes())]
             )
+
+
+class TestVariational:
+    """
+    Tests for tsdate with variational algorithm
+    """
+
+    def test_simple_sim_1_tree(self):
+        ts = msprime.simulate(8, mutation_rate=5, random_seed=2)
+        tsdate.date(ts, mutation_rate=5, population_size=1, method="variational_gamma")
+
+    def test_simple_sim_multi_tree(self):
+        ts = msprime.simulate(8, mutation_rate=5, recombination_rate=5, random_seed=2)
+        tsdate.date(ts, mutation_rate=5, population_size=1, method="variational_gamma")
+
+    def test_nonglobal_priors(self):
+        ts = msprime.simulate(8, mutation_rate=5, recombination_rate=5, random_seed=2)
+        priors = tsdate.prior.MixturePrior(ts, prior_distribution="gamma")
+        grid = priors.make_parameter_grid(population_size=1)
+        grid.grid_data[:] = [1.0, 0.0]  # noninformative prior
+        tsdate.date(
+            ts,
+            mutation_rate=5,
+            method="variational_gamma",
+            priors=grid,
+            global_prior=False,
+        )
+
+    def test_bad_arguments(self):
+        ts = utility_functions.two_tree_mutation_ts()
+        with pytest.raises(ValueError, match="Maximum number of iterations"):
+            tsdate.date(
+                ts,
+                mutation_rate=5,
+                population_size=1,
+                method="variational_gamma",
+                max_iterations=-1,
+            )

--- a/tsdate/approx.py
+++ b/tsdate/approx.py
@@ -1,0 +1,186 @@
+# MIT License
+#
+# Copyright (c) 2021-23 Tskit Developers
+# Copyright (c) 2020-21 University of Oxford
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+Tools for approximating combinations of Gamma variates with Gamma distributions
+"""
+import numba
+import numpy as np
+
+from . import hypergeo
+
+
+@numba.njit("UniTuple(float64, 3)(float64, float64)")
+def approximate_log_moments(mean, variance):
+    """
+    Approximate log moments via a second-order Taylor series expansion around
+    the mean, e.g.:
+
+      E[f(x)] \\approx E[f(mean)] + variance * f''(mean)/2
+
+    Returns approximations to E[log x], E[x log x], E[(log x)^2]
+    """
+    assert mean > 0
+    assert variance > 0
+    logx = np.log(mean) - 0.5 * variance / mean**2
+    xlogx = mean * np.log(mean) + 0.5 * variance / mean
+    logx2 = np.log(mean) ** 2 + (1 - np.log(mean)) * variance / mean**2
+    return logx, xlogx, logx2
+
+
+@numba.njit("UniTuple(float64, 2)(float64, float64)")
+def approximate_gamma_mom(mean, variance):
+    """
+    Use the method of moments to approximate a distribution with a gamma of the
+    same mean and variance
+    """
+    assert mean > 0
+    assert variance > 0
+    alpha = mean**2 / variance
+    beta = mean / variance
+    return alpha, beta
+
+
+@numba.njit("UniTuple(float64, 2)(float64, float64)")
+def approximate_gamma_kl(x, logx):
+    """
+    Use Newton root finding to get gamma parameters matching the sufficient
+    statistics :math:`E[x]` and :math:`E[\\log x]`, minimizing KL divergence.
+
+    The initial condition uses the upper bound :math:`digamma(x) \\leq log(x) - 1/2x`.
+
+    Returns the shape and rate of the approximating gamma.
+    """
+    assert np.isfinite(x) and np.isfinite(logx)
+    alpha = 0.5 / (np.log(x) - logx)  # lower bound on alpha
+    assert alpha > 0, "kl-min: bad initial condition"
+    last = np.inf
+    itt = 0
+    while np.abs(alpha - last) > alpha * 1e-8:
+        last = alpha
+        numer = hypergeo._digamma(alpha) - np.log(alpha) - logx + np.log(x)
+        denom = hypergeo._trigamma(alpha) - 1 / alpha
+        alpha -= numer / denom
+        itt += 1
+    assert np.isfinite(alpha) and alpha > 0, "kl-min: failed"
+    beta = alpha / x
+    return alpha, beta
+
+
+@numba.njit("UniTuple(float64, 2)(float64[:], float64[:])")
+def average_gammas(shape, rate):
+    """
+    Given shape and rate parameters for a set of gammas, average sufficient
+    statistics so as to get a "global" gamma
+    """
+    assert shape.size == rate.size, "Array sizes are not equal"
+    avg_x = 0.0
+    avg_logx = 0.0
+    for a, b in zip(shape, rate):
+        avg_logx += hypergeo._digamma(a) - np.log(b)
+        avg_x += a / b
+    avg_x /= shape.size
+    avg_logx /= shape.size
+    return approximate_gamma_kl(avg_x, avg_logx)
+
+
+@numba.njit(
+    "UniTuple(float64, 5)(float64, float64, float64, float64, float64, float64)"
+)
+def sufficient_statistics(a_i, b_i, a_j, b_j, y_ij, mu_ij):
+    """
+    Calculate gamma sufficient statistics for the PDF proportional to
+    :math:`Ga(t_j | a_j, b_j) Ga(t_i | a_i, b_i) Po(y_{ij} |
+    \\mu_{ij} t_i - t_j)`, where :math:`i` is the parent and :math:`j` is
+    the child.
+
+    :param float a_i: the shape parameter of the cavity distribution for the parent
+    :param float b_i: the rate parameter of the cavity distribution for the parent
+    :param float a_j: the shape parameter of the cavity distribution for the child
+    :param float b_j: the rate parameter of the cavity distribution for the child
+    :param float y_ij: the number of mutations on the edge
+    :param float mu_ij: the span-weighted mutation rate of the edge
+
+    :return: normalizing constant, E[t_i], E[log t_i], E[t_j], E[log t_j]
+    """
+    assert a_i > 0 and b_i > 0, "Invalid parent parameters"
+    assert a_j > 0 and b_j > 0, "Invalid child parameters"
+    assert y_ij >= 0 and mu_ij > 0, "Invalid edge parameters"
+
+    a = a_i + a_j + y_ij
+    b = a_j
+    c = a_j + y_ij + 1
+    t = mu_ij + b_i
+
+    log_f, sign_f, da_i, db_i, da_j, db_j = hypergeo._hyp2f1(
+        a_i, b_i, a_j, b_j, y_ij, mu_ij
+    )
+
+    if sign_f <= 0:
+        raise hypergeo.Invalid2F1("Singular hypergeometric function")
+
+    logconst = (
+        log_f + hypergeo._betaln(y_ij + 1, b) + hypergeo._gammaln(a) - a * np.log(t)
+    )
+
+    t_i = -db_i + a / t
+    t_j = -db_j
+    ln_t_i = da_i - np.log(t) + hypergeo._digamma(a)
+    ln_t_j = (
+        da_j
+        - np.log(t)
+        + hypergeo._digamma(a)
+        + hypergeo._digamma(b)
+        - hypergeo._digamma(c)
+    )
+
+    return logconst, t_i, ln_t_i, t_j, ln_t_j
+
+
+@numba.njit(
+    "Tuple((float64, float64[:], float64[:]))"
+    "(float64, float64, float64, float64, float64, float64)"
+)
+def gamma_projection(a_i, b_i, a_j, b_j, y_ij, mu_ij):
+    """
+    Match a pair of gamma distributions to the potential function
+    :math:`Ga(t_j | a_j, b_j) Ga(t_i | a_i, b_i) Po(y_{ij} |
+    \\mu_{ij} t_i - t_j)`, where :math:`i` is the parent and :math:`j` is
+    the child, by minimizing KL divergence.
+
+    :param float a_i: the shape parameter of the cavity distribution for the parent
+    :param float b_i: the rate parameter of the cavity distribution for the parent
+    :param float a_j: the shape parameter of the cavity distribution for the child
+    :param float b_j: the rate parameter of the cavity distribution for the child
+    :param float y_ij: the number of mutations on the edge
+    :param float mu_ij: the span-weighted mutation rate of the edge
+
+    :return: gamma parameters for parent and child
+    """
+    logconst, t_i, ln_t_i, t_j, ln_t_j = sufficient_statistics(
+        a_i, b_i, a_j, b_j, y_ij, mu_ij
+    )
+
+    alpha_i, beta_i = approximate_gamma_kl(t_i, ln_t_i)
+    alpha_j, beta_j = approximate_gamma_kl(t_j, ln_t_j)
+
+    return logconst, np.array([alpha_i, beta_i]), np.array([alpha_j, beta_j])

--- a/tsdate/approx.py
+++ b/tsdate/approx.py
@@ -75,7 +75,9 @@ def approximate_gamma_kl(x, logx):
     assert alpha > 0, "kl-min: bad initial condition"
     last = np.inf
     itt = 0
-    while np.abs(alpha - last) > alpha * 1e-8:
+    # determine convergence when the change in alpha falls below
+    # some small value (e.g. square root of machine precision)
+    while np.abs(alpha - last) > alpha * np.sqrt(np.finfo(np.float64).eps):
         last = alpha
         numer = hypergeo._digamma(alpha) - np.log(alpha) - logx + np.log(x)
         denom = hypergeo._trigamma(alpha) - 1 / alpha

--- a/tsdate/approx.py
+++ b/tsdate/approx.py
@@ -111,8 +111,8 @@ def sufficient_statistics(a_i, b_i, a_j, b_j, y_ij, mu_ij):
 
     :return: normalizing constant, E[t_i], E[log t_i], E[t_j], E[log t_j]
     """
-    assert a_i > 0 and b_i > 0, "Invalid parent parameters"
-    assert a_j > 0 and b_j > 0, "Invalid child parameters"
+    assert a_i > 0 and b_i >= 0, "Invalid parent parameters"
+    assert a_j > 0 and b_j >= 0, "Invalid child parameters"
     assert y_ij >= 0 and mu_ij > 0, "Invalid edge parameters"
 
     a = a_i + a_j + y_ij

--- a/tsdate/approx.py
+++ b/tsdate/approx.py
@@ -48,19 +48,6 @@ def approximate_log_moments(mean, variance):
 
 
 @numba.njit("UniTuple(float64, 2)(float64, float64)")
-def approximate_gamma_mom(mean, variance):
-    """
-    Use the method of moments to approximate a distribution with a gamma of the
-    same mean and variance
-    """
-    assert mean > 0
-    assert variance > 0
-    alpha = mean**2 / variance
-    beta = mean / variance
-    return alpha, beta
-
-
-@numba.njit("UniTuple(float64, 2)(float64, float64)")
 def approximate_gamma_kl(x, logx):
     """
     Use Newton root finding to get gamma parameters matching the sufficient

--- a/tsdate/base.py
+++ b/tsdate/base.py
@@ -31,6 +31,7 @@ import numpy as np
 FLOAT_DTYPE = np.float64
 LIN = "linear"
 LOG = "logarithmic"
+PAR = "parameter"
 
 # Bit 20 is set in node flags when they are samples not at time zero in the sampledata
 # file
@@ -123,6 +124,11 @@ class NodeGridValues:
                     self.grid_data = np.log(self.grid_data)
                     self.fixed_data = np.log(self.fixed_data)
                 self.probability_space = LOG
+            else:
+                logging.warning("Cannot force", *descr)
+        elif probability_space == PAR:
+            if self.probability_space == PAR:
+                pass
             else:
                 logging.warning("Cannot force", *descr)
         else:

--- a/tsdate/base.py
+++ b/tsdate/base.py
@@ -31,7 +31,7 @@ import numpy as np
 FLOAT_DTYPE = np.float64
 LIN = "linear"
 LOG = "logarithmic"
-PAR = "parameter"
+GAMMA_PAR = "gamma_parameter"
 
 # Bit 20 is set in node flags when they are samples not at time zero in the sampledata
 # file
@@ -126,8 +126,8 @@ class NodeGridValues:
                 self.probability_space = LOG
             else:
                 logging.warning("Cannot force", *descr)
-        elif probability_space == PAR:
-            if self.probability_space == PAR:
+        elif probability_space == GAMMA_PAR:
+            if self.probability_space == GAMMA_PAR:
                 pass
             else:
                 logging.warning("Cannot force", *descr)

--- a/tsdate/core.py
+++ b/tsdate/core.py
@@ -908,9 +908,36 @@ class InOutAlgorithms:
 
 
 class ExpectationPropagation(InOutAlgorithms):
-    """
-    Expectation propagation, where the edge factors are approximated
-    by the product of two gamma distributions
+    r"""
+    Expectation propagation (EP) algorithm to infer approximate marginal
+    distributions for node ages.
+
+    The model has the form,
+
+    .. math::
+
+        \prod_{i \in \mathcal{N} f(t_i | \theta_i)
+        \prod_{(i,j) \in \mathcal{E}} g(y_ij | t_i - t_j)
+
+    Where :math:`f(.)` is a prior distribution on node ages with parameters
+    :math:`\\theta` and :math:`g(.)` are Poisson likelihoods per edge. The
+    EP approximation has the form,
+
+    .. math::
+
+        \prod_{i \in \mathcal{N} q(t_i | \eta_i)
+        \prod_{(i,j) \in \mathcal{E}} q(t_i | \gamma_{ij}) q(t_j | \kappa_{ij})
+
+    Here, :math:`q(.)` are pseudo-gamma distributions (termed 'factors'), and
+    :math:`\eta, \gamma, \kappa` are variational parameters that reflect to
+    prior, inside (leaf-to-root), and outside (root-to-edge) information.
+
+    Thus, the EP approximation results in gamma-distribution marginals.  The
+    factors :math:`q(.)` do not need to be valid distributions (e.g. the
+    shape/rate parameters may be negative), as long as the marginals are valid
+    distributions.  For details on how the variational parameters are
+    optimized, see Minka (2002) "Expectation Propagation for Approximate
+    Bayesian Inference"
     """
 
     def __init__(self, *args, **kwargs):

--- a/tsdate/core.py
+++ b/tsdate/core.py
@@ -1000,10 +1000,11 @@ class ExpectationPropagation(InOutAlgorithms):
                 continue
             if edge.parent in self.fixednodes:
                 raise ValueError("Internal nodes can not be fixed in EP algorithm")
+            # Get the edge likelihood (Poisson) in terms of a gamma distribution
             edge_lik = self.lik.to_gamma(edge, natural=True)
             # Get the cavity posteriors: that is, the rest of the approximation
-            # without the factor for this edge. This only involves the variational
-            # parameters for the parent and child on the edge.
+            # without the factor for this edge. This only involves updating the
+            # variational parameters for the parent and child on the edge.
             parent_cavity = self.lik.ratio(
                 self.posterior[edge.parent], self.parent_message[edge.id]
             )
@@ -1019,14 +1020,16 @@ class ExpectationPropagation(InOutAlgorithms):
                 self.posterior[edge.child],
             ) = approx.gamma_projection(*parent_cavity, *child_cavity, *edge_lik)
             # Get the messages: that is, the multiplicative difference between
-            # the target and cavity posteriors.
+            # the target and cavity posteriors. This only involves updating the
+            # variational parameters for the parent and child on the edge.
             self.parent_message[edge.id] = self.lik.ratio(
                 self.posterior[edge.parent], parent_cavity
             )
             self.child_message[edge.id] = self.lik.ratio(
                 self.posterior[edge.child], child_cavity
             )
-            # Get the approximation to the marginal likelihood
+            # Get the contribution to the (approximate) marginal likelihood from
+            # the edge.
             # TODO not complete
             self.factor_norm[edge.id] = norm_const
 

--- a/tsdate/core.py
+++ b/tsdate/core.py
@@ -561,14 +561,20 @@ class VariationalLikelihoods:
     @staticmethod
     def combine(base, message):
         """
-        Multiply two gamma PDFs
+        Multiply two gamma PDFs in shape/rate parameterization. This
+        is equivalent to addition of natural parameters. Because the natural
+        parametrization is (shape - 1, rate), the operation returns
+        [(base_shape - 1) + (message_shape - 1) + 1, base_rate + message_rate]
         """
         return base + message + [-1, 0]
 
     @staticmethod
     def ratio(base, message):
         """
-        Divide two gamma PDFs
+        Divide two gamma PDFs in shape/rate parameterization. This
+        is equivalent to subtraction of natural parameters. Because the natural
+        parametrization is (shape - 1, rate), the operation returns
+        [(base_shape - 1) - (message_shape - 1) + 1, base_rate - message_rate]
         """
         return base - message + [1, 0]
 

--- a/tsdate/core.py
+++ b/tsdate/core.py
@@ -911,7 +911,7 @@ class InOutAlgorithms:
 
 class ExpectationPropagation(InOutAlgorithms):
     """
-    Implements expectation propagation, where the edge factors are approximated
+    Expectation propagation, where the edge factors are approximated
     by the product of two gamma distributions
     """
 
@@ -954,8 +954,6 @@ class ExpectationPropagation(InOutAlgorithms):
                 )
                 # self.factor_norm[edge.id] += ... # TODO
 
-        # prior contribution to marginal likelihood? TODO
-
     def edges_by_parent_asc(self):
         """
         Edges in order of increasing age of parent
@@ -980,50 +978,6 @@ class ExpectationPropagation(InOutAlgorithms):
             for i in reversed(np.argsort(w, order=("child_age", "child_node")))
         )
         return sorted_child_parent
-
-    # def propagate(self, *, edges, progress=None):
-    #    """
-    #    Update approximating factor for each edge
-    #    """
-    #    if progress is None:
-    #        progress = self.progress
-    #    # TODO: this will still converge if parallelized (potentially slower)
-    #    for edge in tqdm(
-    #        edges,
-    #        desc="Expectation Propagation",
-    #        total=self.ts.num_edges,
-    #        disable=not progress,
-    #    ):
-    #        if edge.child in self.fixednodes:
-    #            continue
-    #        if edge.parent in self.fixednodes:
-    #            raise ValueError("Internal nodes can not be fixed in EP algorithm")
-    #        edge_potential = self.lik.to_gamma(edge)
-    #        edge_potential += np.array([-1.0, 0.0])  # to Poisson, TODO cleanup
-    #        # create posteriors without approximate edge factor
-    #        parent_cavity = self.lik.ratio(
-    #            self.posterior[edge.parent], self.parent_message[edge.id]
-    #        )
-    #        child_cavity = self.lik.ratio(
-    #            self.posterior[edge.child], self.child_message[edge.id]
-    #        )
-    #        # target posterior matching cavity + exact edge factor
-    #        parent_norm, *self.posterior[edge.parent] = approx.inside_potential(
-    #            *parent_cavity, *child_cavity, *edge_potential
-    #        )
-    #        child_norm, *self.posterior[edge.child] = approx.outside_potential(
-    #            *parent_cavity, *child_cavity, *edge_potential
-    #        )
-    #        # store approximate edge factors including normalizer
-    #        self.parent_message[edge.id] = self.lik.ratio(
-    #            self.posterior[edge.parent], parent_cavity
-    #        )
-    #        self.child_message[edge.id] = self.lik.ratio(
-    #            self.posterior[edge.child], child_cavity
-    #        )
-    #        # store target normalizing constants
-    #        # TODO: this isn't quite right
-    #        self.factor_norm[edge.id] = 0.5 * parent_norm + 0.5 * child_norm
 
     def propagate(self, *, edges, progress=None):
         """
@@ -1064,7 +1018,6 @@ class ExpectationPropagation(InOutAlgorithms):
             self.child_message[edge.id] = self.lik.ratio(
                 self.posterior[edge.child], child_cavity
             )
-            # TODO: this isn't quite right
             self.factor_norm[edge.id] = norm_const
 
     def iterate(self, *, progress=None, **kwargs):
@@ -1074,11 +1027,9 @@ class ExpectationPropagation(InOutAlgorithms):
         """
         self.propagate(edges=self.edges_by_parent_asc(), progress=progress)
         self.propagate(edges=self.edges_by_child_desc(), progress=progress)
-        marginal_lik = np.sum(self.factor_norm)
-        # marginal_lik = np.sum(
-        #    [approx.log_partition_gamma(*pars) for pars in self.posterior.grid_data]
-        # )
-        return marginal_lik
+        # TODO
+        # marginal_lik = np.sum(self.factor_norm)
+        # return marginal_lik
 
 
 def posterior_mean_var(ts, posterior, *, fixed_node_set=None):

--- a/tsdate/core.py
+++ b/tsdate/core.py
@@ -1023,6 +1023,8 @@ class ExpectationPropagation(InOutAlgorithms):
             self.child_message[edge.id] = self.lik.ratio(
                 self.posterior[edge.child], child_cavity
             )
+            # Get the approximation to the marginal likelihood
+            # TODO not complete
             self.factor_norm[edge.id] = norm_const
 
     def iterate(self, *, progress=None, **kwargs):

--- a/tsdate/core.py
+++ b/tsdate/core.py
@@ -512,6 +512,10 @@ class LogLikelihoods(Likelihoods):
 class VariationalLikelihoods:
     """
     A class to store and process likelihoods for use in variational inference.
+    Has two main purposes: to store mutation counts / rates for Poisson
+    likelihoods per edge, and to perform binary operations gamma distributions
+    in terms of their natural parameterization (e.g. adding / subtracting sufficient
+    statistics is equivalent to multiplying / dividing gamma PDFs).
     """
 
     probability_space = base.GAMMA_PAR
@@ -567,18 +571,6 @@ class VariationalLikelihoods:
         Divide two gamma PDFs
         """
         return base - message + [1, 0]
-
-    @staticmethod
-    def scale_geometric(fraction, pars):
-        """
-        Scale the parameters of a gamma distribution by raising the PDF to a
-        fractional power.
-        """
-        assert 1 >= fraction >= 0
-        new_pars = pars.copy()
-        new_pars[0] = fraction * (new_pars[0] - 1) + 1
-        new_pars[1] = fraction * new_pars[1]
-        return new_pars
 
 
 class InOutAlgorithms:

--- a/tsdate/core.py
+++ b/tsdate/core.py
@@ -514,7 +514,7 @@ class VariationalLikelihoods:
     A class to store and process likelihoods for use in variational inference.
     """
 
-    probability_space = base.PAR
+    probability_space = base.GAMMA_PAR
     identity_constant = np.array([1.0, 0.0], dtype=float)  # "improper" gamma prior
     null_constant = 0.0
     timepoints = np.array([0, np.inf], dtype=float)
@@ -918,8 +918,8 @@ class ExpectationPropagation(InOutAlgorithms):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        assert self.priors.probability_space == base.PAR
-        assert self.lik.probability_space == base.PAR
+        assert self.priors.probability_space == base.GAMMA_PAR
+        assert self.lik.probability_space == base.GAMMA_PAR
         assert self.lik.grid_size == 2
         assert self.priors.timepoints.size == 2
 

--- a/tsdate/core.py
+++ b/tsdate/core.py
@@ -946,31 +946,6 @@ class ExpectationPropagation(InOutAlgorithms):
                 )
                 # self.factor_norm[edge.id] += ... # TODO
 
-    def edges_by_parent_asc(self):
-        """
-        Edges in order of increasing age of parent
-        """
-        return self.ts.edges()
-
-    def edges_by_child_desc(self):
-        """
-        Edges in order of decreasing age of child
-        """
-        wtype = np.dtype(
-            [
-                ("child_age", self.ts.tables.nodes.time.dtype),
-                ("child_node", self.ts.tables.edges.child.dtype),
-            ]
-        )
-        w = np.empty(self.ts.num_edges, dtype=wtype)
-        w["child_age"] = self.ts.tables.nodes.time[self.ts.tables.edges.child]
-        w["child_node"] = self.ts.tables.edges.child
-        sorted_child_parent = (
-            self.ts.edge(i)
-            for i in reversed(np.argsort(w, order=("child_age", "child_node")))
-        )
-        return sorted_child_parent
-
     def propagate(self, *, edges, progress=None):
         """
         Update approximating factor for each edge

--- a/tsdate/core.py
+++ b/tsdate/core.py
@@ -630,7 +630,7 @@ class InOutAlgorithms:
 
     # === Grouped edge iterators ===
 
-    def edges_by_parent_asc(self):
+    def edges_by_parent_asc(self, grouped=True):
         """
         Return an itertools.groupby object of edges grouped by parent in ascending order
         of the time of the parent. Since tree sequence properties guarantee that edges
@@ -638,9 +638,12 @@ class InOutAlgorithms:
         (https://tskit.readthedocs.io/en/latest/data-model.html#edge-requirements)
         we can simply use the standard edge order
         """
-        return itertools.groupby(self.ts.edges(), operator.attrgetter("parent"))
+        if grouped:
+            return itertools.groupby(self.ts.edges(), operator.attrgetter("parent"))
+        else:
+            return self.ts.edges()
 
-    def edges_by_child_desc(self):
+    def edges_by_child_desc(self, grouped=True):
         """
         Return an itertools.groupby object of edges grouped by child in descending order
         of the time of the child.
@@ -651,9 +654,12 @@ class InOutAlgorithms:
                 (self.ts.edges_child, -self.ts.nodes_time[self.ts.edges_child])
             )
         )
-        return itertools.groupby(it, operator.attrgetter("child"))
+        if grouped:
+            return itertools.groupby(it, operator.attrgetter("child"))
+        else:
+            return it
 
-    def edges_by_child_then_parent_desc(self):
+    def edges_by_child_then_parent_desc(self, grouped=True):
         """
         Return an itertools.groupby object of edges grouped by child in descending order
         of the time of the child, then by descending order of age of child
@@ -675,7 +681,10 @@ class InOutAlgorithms:
                 np.argsort(w, order=("child_age", "child_node", "parent_age"))
             )
         )
-        return itertools.groupby(sorted_child_parent, operator.attrgetter("child"))
+        if grouped:
+            return itertools.groupby(sorted_child_parent, operator.attrgetter("child"))
+        else:
+            return sorted_child_parent
 
     # === MAIN ALGORITHMS ===
 
@@ -1038,8 +1047,8 @@ class ExpectationPropagation(InOutAlgorithms):
         Update edge factors from leaves to root then from root to leaves,
         and return approximate log marginal likelihood
         """
-        self.propagate(edges=self.edges_by_parent_asc(), progress=progress)
-        self.propagate(edges=self.edges_by_child_desc(), progress=progress)
+        self.propagate(edges=self.edges_by_parent_asc(grouped=False), progress=progress)
+        self.propagate(edges=self.edges_by_child_desc(grouped=False), progress=progress)
         # TODO
         # marginal_lik = np.sum(self.factor_norm)
         # return marginal_lik

--- a/tsdate/hypergeo.py
+++ b/tsdate/hypergeo.py
@@ -1,0 +1,470 @@
+# MIT License
+#
+# Copyright (c) 2021-23 Tskit Developers
+# Copyright (c) 2020-21 University of Oxford
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+Numerically stable implementations of the Gauss hypergeometric function with numba.
+"""
+import ctypes
+
+import numba
+import numpy as np
+from numba.extending import get_cython_function_address
+
+_HYP2F1_TOL = np.sqrt(np.finfo(np.float64).eps)
+_HYP2F1_CHECK = np.sqrt(_HYP2F1_TOL)
+_HYP2F1_MAXTERM = int(1e6)
+
+_PTR = ctypes.POINTER
+_dbl = ctypes.c_double
+_ptr_dbl = _PTR(_dbl)
+_gammaln_addr = get_cython_function_address("scipy.special.cython_special", "gammaln")
+_gammaln_functype = ctypes.CFUNCTYPE(_dbl, _dbl)
+_gammaln_float64 = _gammaln_functype(_gammaln_addr)
+
+
+class Invalid2F1(Exception):
+    pass
+
+
+@numba.njit("float64(float64)")
+def _gammaln(x):
+    return _gammaln_float64(x)
+
+
+@numba.njit("float64(float64)")
+def _digamma(x):
+    """
+    digamma (psi) function, from asymptotic series expansion
+    """
+    if x <= 0.0:
+        return np.nan
+    if x <= 1e-5:
+        return -np.euler_gamma - (1 / x)
+    if x < 8.5:
+        return _digamma(1 + x) - 1 / x
+    xpm2 = 1 / x**2
+    return (
+        np.log(x)
+        - 0.5 / x
+        - 0.083333333333333333 * xpm2
+        + 0.008333333333333333 * xpm2**2
+        - 0.003968253968253968 * xpm2**3
+        + 0.004166666666666667 * xpm2**4
+        - 0.007575757575757576 * xpm2**5
+        + 0.021092796092796094 * xpm2**6
+    )
+
+
+@numba.njit("float64(float64)")
+def _trigamma(x):
+    """
+    trigamma function, from asymptotic series expansion
+    """
+    if x <= 0.0:
+        return np.nan
+    if x <= 1e-4:
+        return 1 / x**2
+    if x < 5:
+        return _trigamma(1 + x) + 1 / x**2
+    xpm1 = 1 / x
+    xpm2 = 1 / x**2
+    return xpm1 * (
+        1.000000000000000000
+        + 0.500000000000000000 * xpm1
+        + 0.166666666666666667 * np.power(xpm2, 1)
+        - 0.033333333333333333 * np.power(xpm2, 2)
+        + 0.023809523809523808 * np.power(xpm2, 3)
+        - 0.033333333333333333 * np.power(xpm2, 4)
+        + 0.075757575757575756 * np.power(xpm2, 5)
+        - 0.253113553113553102 * np.power(xpm2, 6)
+        + 1.166666666666666741 * np.power(xpm2, 7)
+    )
+
+
+@numba.njit("float64(float64, float64)")
+def _betaln(p, q):
+    return _gammaln(p) + _gammaln(q) - _gammaln(p + q)
+
+
+@numba.njit("boolean(float64, float64, float64, float64, float64, float64)")
+def _is_valid_2f1(f1, f2, a, b, c, z):
+    """
+    Use the contiguous relation between the Gauss hypergeometric function and
+    its first and second derivatives to check its numerical accuracy. The first
+    and second derivatives are assumed to be normalized by the function value.
+
+    See Eq. 6 in https://doi.org/10.1016/j.cpc.2007.11.007
+    """
+    if z == 0.0:
+        return np.abs(f1 - a * b / c) < _HYP2F1_CHECK
+    u = c - (a + b + 1) * z
+    v = a * b
+    w = z * (1 - z)
+    denom = np.abs(f1) + np.abs(f2) + 1.0
+    if z == 1.0:
+        numer = np.abs(u * f1 - v)
+    else:
+        numer = np.abs(f2 + u / w * f1 - v / w)
+    return numer / denom < _HYP2F1_CHECK
+
+
+@numba.njit("UniTuple(float64, 7)(float64, float64, float64, float64)")
+def _hyp2f1_taylor_series(a, b, c, z):
+    """
+    Evaluate a Gaussian hypergeometric function, via its Taylor series at the
+    origin.  Also returns the gradient with regard to `a`, `b`, and `c`; and
+    first and second partial derivatives wrt `z`. Requires :math:`1 > z >= 0`.
+
+    To avoid overflow, returns the function value on a log scale and the
+    derivatives divided by the (unlogged) function value.
+    """
+    assert 1.0 > z >= 0.0
+    assert a >= 0.0
+    assert b >= 0.0
+    assert c > 0.0
+
+    if z == 0.0:
+        sign = 1.0
+        val = 0.0
+        da = 0.0
+        db = 0.0
+        dc = 0.0
+        dz = a * b / c
+        d2z = dz * (a + 1) * (b + 1) / (c + 1)
+    else:
+        k = 1
+        val = 1.0
+        ltol = np.log(_HYP2F1_TOL)
+        zk = 0.0  # multiplicative increment for parameter (log)
+        iz = 0.0  # additive increment for parameter
+        dz = 0.0  # partial derivative of parameter
+        d2z = 0.0  # second order derivative of parameter
+        arg = np.array([a, b, c])
+        argk = np.zeros(3)  # multiplicative increment for args (log)
+        argd = np.zeros(3)  # additive increment for args
+        argp = np.zeros(3)  # partial derivatives of args
+        offset = 0.0  # maximum increment encountered
+        while k < _HYP2F1_MAXTERM:
+            argk += np.log(arg + k - 1)
+            argd += 1 / (arg + k - 1)
+            zk += np.log(z) - np.log(k)
+            iz += 1 / z
+            weight = argk[0] + argk[1] - argk[2] + zk
+            norm = np.exp(weight - offset)
+            if weight < offset:
+                val += norm
+                argp += argd * norm
+                dz += iz * norm
+                d2z += iz * (iz - 1 / z) * norm
+            else:
+                val = 1.0 + val / norm
+                argp = argd + argp / norm
+                dz = iz + dz / norm
+                d2z = iz * (iz - 1 / z) + d2z / norm
+                offset = weight
+            if not np.isfinite(val):
+                raise Invalid2F1("Hypergeometric series did not converge")
+            if weight < ltol + np.log(val) and _is_valid_2f1(
+                dz / val, d2z / val, a, b, c, z
+            ):
+                break
+            k += 1
+        argp /= val
+        da = argp[0]
+        db = argp[1]
+        dc = -argp[2]
+        dz /= val
+        d2z /= val
+        sign = 1.0
+        val = np.log(val) + offset
+    if k >= _HYP2F1_MAXTERM:
+        raise Invalid2F1("Hypergeometric series did not converge")
+    return val, sign, da, db, dc, dz, d2z
+
+
+@numba.njit("UniTuple(float64, 7)(float64, float64, float64, float64)")
+def _hyp2f1_recurrence(a, b, c, z):
+    """
+    Evaluate 2F1(a, -b; c; z) where b is an integer using (0, -1, 0) recurrence.
+    See https://doi.org/10.48550/arXiv.1909.10765
+
+    Returns log function value, sign, gradient, and second derivative wrt z. The
+    derivatives are divided by the function value.
+    """
+    # TODO
+    # fails with (200.0, 101.0, 401.6, 1.1)
+    assert b % 1.0 == 0.0 and b >= 0
+    assert np.abs(c) >= np.abs(a)
+    assert 2.0 > z > 1.0  # TODO: generalize
+    f0 = 1.0
+    f1 = 1 - a * z / c
+    s0 = 1.0
+    s1 = np.sign(f1)
+    g0 = np.zeros(4)  # df/da df/db df/dc df/dz
+    g1 = np.array([-z / c, 0.0, a * z / c**2, -a / c]) / f1
+    p0 = 0.0  # d2f/dz2
+    p1 = 0.0
+    f0 = np.log(np.abs(f0))
+    f1 = np.log(np.abs(f1))
+    if b == 0:
+        return f0, s0, g0[0], g0[1], g0[2], g0[3], p0
+    if b == 1:
+        return f1, s1, g1[0], g1[1], g1[2], g1[3], p1
+    for n in range(1, int(b)):
+        ak = n * (z - 1) / (c + n)
+        dak = np.array([0.0, 0.0, -ak / (c + n), ak / (z - 1)])
+        bk = (2 * n + c - z * (a + n)) / (c + n)
+        dbk = np.array([-z / (c + n), 0.0, (1 - bk) / (c + n), -(a + n) / (c + n)])
+        u = s0 * np.exp(f0 - f1)
+        v = s1 * bk + u * ak
+        s = np.sign(v)
+        f = np.log(np.abs(v)) + f1
+        g = (g1 * bk * s1 + g0 * u * ak + dbk * s1 + dak * u) / v
+        p = (
+            p1 * bk * s1
+            + p0 * u * ak
+            + 2 / (c + n) * (u * g0[3] * n - s1 * g1[3] * (a + n))
+        ) / v
+        f1, f0 = f, f1
+        s1, s0 = s, s1
+        g1, g0 = g, g1
+        p1, p0 = p, p1
+    if not _is_valid_2f1(g[3], p, a, -b, c, z):
+        raise Invalid2F1("Hypergeometric series did not converge")
+    da, db, dc, dz = g
+    return f, s, da, db, dc, dz, p
+
+
+@numba.njit(
+    "UniTuple(float64, 6)(float64, float64, float64, float64, float64, float64)"
+)
+def _hyp2f1_dlmf1583_first(a_i, b_i, a_j, b_j, y, mu):
+    """
+    DLMF 15.8.3, first term
+
+    F(a_j, 1 - a_i; 1 - a_i - y; 1/(1 - z))
+
+    Use Pfaff transform,
+
+    (1 - 1 / (1 - z))**(-a_j) F(a_j, -y; 1 - a_i - y; 1 / z)
+
+    Then rearrange terms in series to get,
+
+    (1 - a_i - a_j - y)_y / (1 - a_i - y)_y \\times
+      (1 - 1/(1-z))^(-a_j) \\times
+        F(a_j, -y; a_j + a_i; 1 - 1/z)
+    """
+
+    a = a_j
+    c = a_j + a_i
+    s = (b_j - mu) / (mu + b_i)
+    z = (b_j + b_i) / (b_j - mu)
+    scale = (
+        -a_j * np.log(s)
+        + _gammaln(a_j + y + 1)
+        - _gammaln(y + 1)
+        + _gammaln(a_i)
+        - _gammaln(a_i + a_j)
+    )
+
+    # 2F1(a, -y; c; z) via backwards recurrence
+    val, sign, da, _, dc, dz, _ = _hyp2f1_recurrence(a, y, c, z)
+
+    # map gradient to parameters
+    da_i = dc - _digamma(a_i + a_j) + _digamma(a_i)
+    da_j = da + dc - np.log(s) + _digamma(a_j + y + 1) - _digamma(a_i + a_j)
+    db_i = dz / (b_j - mu) + a_j / (mu + b_i)
+    db_j = dz * (1 - z) / (b_j - mu) - a_j / s / (mu + b_i)
+
+    val += scale
+
+    return val, sign, da_i, db_i, da_j, db_j
+
+
+@numba.njit(
+    "UniTuple(float64, 6)(float64, float64, float64, float64, float64, float64)"
+)
+def _hyp2f1_dlmf1583_second(a_i, b_i, a_j, b_j, y, mu):
+    """
+    DLMF 15.8.3, second term
+    """
+    y = int(y)
+    a = a_i + a_j + y
+    c = a_i + y + 1
+    z = (b_i + mu) / (b_i + b_j)
+    scale = (
+        _gammaln(a_j + y + 1)
+        - _gammaln(a_j)
+        + _gammaln(a_i)
+        - _gammaln(a_i + y + 1)
+        + (a_i + a_j + y) * np.log(z)
+    )
+
+    # 2F1(a, y+1; c; z) via series expansion
+    val, sign, da, _, dc, dz, _ = _hyp2f1_taylor_series(a, y + 1, c, z)
+
+    # map gradient to parameters
+    da_i = da + np.log(z) + dc + _digamma(a_i) - _digamma(a_i + y + 1)
+    da_j = da + np.log(z) + _digamma(a_j + y + 1) - _digamma(a_j)
+    db_i = (1 - z) * (dz + a / z) / (b_i + b_j)
+    db_j = -z * (dz + a / z) / (b_i + b_j)
+
+    sign *= (-1) ** (y + 1)
+    val += scale
+
+    return val, sign, da_i, db_i, da_j, db_j
+
+
+@numba.njit(
+    "UniTuple(float64, 6)(float64, float64, float64, float64, float64, float64)"
+)
+def _hyp2f1_dlmf1583(a_i, b_i, a_j, b_j, y, mu):
+    """
+    DLMF 15.8.3, sum of recurrence and series expansion
+    """
+    assert b_i > 0
+    assert 0 < mu <= b_j
+    assert y >= 0 and y % 1.0 == 0.0
+
+    f_1, s_1, da_i_1, db_i_1, da_j_1, db_j_1 = _hyp2f1_dlmf1583_first(
+        a_i, b_i, a_j, b_j, y, mu
+    )
+
+    f_2, s_2, da_i_2, db_i_2, da_j_2, db_j_2 = _hyp2f1_dlmf1583_second(
+        a_i, b_i, a_j, b_j, y, mu
+    )
+
+    if np.abs(f_1 - f_2) < _HYP2F1_TOL:
+        # TODO: detect a priori if this will occur
+        raise Invalid2F1("Singular hypergeometric function")
+
+    f_0 = max(f_1, f_2)
+    f_1 = np.exp(f_1 - f_0) * s_1
+    f_2 = np.exp(f_2 - f_0) * s_2
+    f = f_1 + f_2
+
+    da_i = (da_i_1 * f_1 + da_i_2 * f_2) / f
+    db_i = (db_i_1 * f_1 + db_i_2 * f_2) / f
+    da_j = (da_j_1 * f_1 + da_j_2 * f_2) / f
+    db_j = (db_j_1 * f_1 + db_j_2 * f_2) / f
+
+    sign = np.sign(f)
+    val = np.log(np.abs(f)) + f_0
+
+    return val, sign, da_i, db_i, da_j, db_j
+
+
+@numba.njit(
+    "UniTuple(float64, 6)(float64, float64, float64, float64, float64, float64)"
+)
+def _hyp2f1_dlmf1521(a_i, b_i, a_j, b_j, y, mu):
+    """
+    DLMF 15.2.1, series expansion without transformation
+    """
+    assert b_i > 0
+    assert mu >= b_j > 0
+    assert y >= 0 and y % 1 == 0.0
+
+    y = int(y)
+    a = a_j
+    b = a_i + a_j + y
+    c = a_j + y + 1
+    z = (mu - b_j) / (mu + b_i)
+
+    # 2F1(a, y+1; c; z) via series expansion
+    val, sign, da, db, dc, dz, _ = _hyp2f1_taylor_series(a, b, c, z)
+
+    # map gradient to parameters
+    da_i = db
+    da_j = da + db + dc
+    db_i = -dz * z / (mu + b_i)
+    db_j = -dz / (mu + b_i)
+
+    return val, sign, da_i, db_i, da_j, db_j
+
+
+@numba.njit(
+    "UniTuple(float64, 6)(float64, float64, float64, float64, float64, float64)"
+)
+def _hyp2f1_dlmf1581(a_i, b_i, a_j, b_j, y, mu):
+    """
+    DLMF 15.8.1, series expansion with Pfaff transformation
+    """
+    assert b_i > 0
+    assert 0 < mu <= b_j
+    assert y >= 0 and y % 1 == 0.0
+
+    y = int(y)
+    a = a_i + a_j + y
+    c = a_j + y + 1
+    z = (b_j - mu) / (b_i + b_j)
+    scale = -a * np.log(1 - z / (z - 1))
+
+    # 2F1(a, y+1; c; z) via series expansion
+    val, sign, da, _, dc, dz, _ = _hyp2f1_taylor_series(a, y + 1, c, z)
+
+    # map gradient to parameters
+    da_i = da - np.log(1 - z / (z - 1))
+    da_j = da + dc - np.log(1 - z / (z - 1))
+    db_i = z * (a / (mu + b_i) - dz / (b_i + b_j))
+    db_j = (z - 1) * (a / (mu + b_i) - dz / (b_i + b_j))
+
+    val += scale
+
+    return val, sign, da_i, db_i, da_j, db_j
+
+
+@numba.njit(
+    "UniTuple(float64, 6)(float64, float64, float64, float64, float64, float64)"
+)
+def _hyp2f1(a_i, b_i, a_j, b_j, y, mu):
+    """
+    Evaluates:
+
+    ..math:
+
+        {2_}F{1_}(a_j, a_i+a_j+y; a_j+y+1; (\\mu-b_j)/(\\mu+b_i))
+
+    where the age of parent :math:`i` and child :math:`j` have marginal shape
+    and rate :math:`a` and :math:`b`; and edge :math:`(i, j)` has :math:`y`
+    observed mutations with span-weighted mutation rate span :math:`\\mu`.
+
+    Returns overflow-protected values of:
+
+      \\log f, df/da_i, df/db_i, d2f/(da_i db_i), df/da_j, df/db_j, d2f/(da_j db_j)
+
+    Overflow protection entails log-transforming the function value,
+    and dividing the gradient by the function value.
+    """
+    z = (mu - b_j) / (mu + b_i)
+    assert z < 1.0  # TODO: allow z == 1.0 for improper prior
+    if 0.0 <= z < 1.0:
+        return _hyp2f1_dlmf1521(a_i, b_i, a_j, b_j, y, mu)
+    elif -1.0 < z < 0.0:
+        return _hyp2f1_dlmf1581(a_i, b_i, a_j, b_j, y, mu)
+    else:
+        try:
+            # if posterior marginals are too incompatible (e.g. parent age
+            # younger than child age) then this transform will diverge
+            return _hyp2f1_dlmf1583(a_i, b_i, a_j, b_j, y, mu)
+        except:  # noqa: E722,B001
+            return _hyp2f1_dlmf1581(a_i, b_i, a_j, b_j, y, mu)

--- a/tsdate/hypergeo.py
+++ b/tsdate/hypergeo.py
@@ -341,8 +341,8 @@ def _hyp2f1_dlmf1583(a_i, b_i, a_j, b_j, y, mu):
     """
     DLMF 15.8.3, sum of recurrence and series expansion
     """
-    assert b_i > 0
-    assert 0 < mu <= b_j
+    assert b_i >= 0
+    assert 0 <= mu <= b_j
     assert y >= 0 and y % 1.0 == 0.0
 
     f_1, s_1, da_i_1, db_i_1, da_j_1, db_j_1 = _hyp2f1_dlmf1583_first(
@@ -380,8 +380,8 @@ def _hyp2f1_dlmf1521(a_i, b_i, a_j, b_j, y, mu):
     """
     DLMF 15.2.1, series expansion without transformation
     """
-    assert b_i > 0
-    assert mu >= b_j > 0
+    assert b_i >= 0
+    assert mu >= b_j >= 0
     assert y >= 0 and y % 1 == 0.0
 
     y = int(y)
@@ -409,8 +409,8 @@ def _hyp2f1_dlmf1581(a_i, b_i, a_j, b_j, y, mu):
     """
     DLMF 15.8.1, series expansion with Pfaff transformation
     """
-    assert b_i > 0
-    assert 0 < mu <= b_j
+    assert b_i >= 0
+    assert 0 <= mu <= b_j
     assert y >= 0 and y % 1 == 0.0
 
     y = int(y)
@@ -456,7 +456,7 @@ def _hyp2f1(a_i, b_i, a_j, b_j, y, mu):
     and dividing the gradient by the function value.
     """
     z = (mu - b_j) / (mu + b_i)
-    assert z < 1.0  # TODO: allow z == 1.0 for improper prior
+    assert z < 1.0, "Invalid hypergeometric function argument"
     if 0.0 <= z < 1.0:
         return _hyp2f1_dlmf1521(a_i, b_i, a_j, b_j, y, mu)
     elif -1.0 < z < 0.0:

--- a/tsdate/prior.py
+++ b/tsdate/prior.py
@@ -1124,7 +1124,7 @@ class MixturePrior:
             ),
             np.array([0, np.inf]),
         )
-        prior_pars.probability_space = base.PAR
+        prior_pars.probability_space = base.GAMMA_PAR
 
         shape_param = self.prior_params[:, PriorParams.field_index("alpha")]
         rate_param = self.prior_params[:, PriorParams.field_index("beta")]


### PR DESCRIPTION
WIP

- Doesn't use a time discretization -- instead, each node has two variational parameters (shape/rate of gamma) for each of inside/outside/posterior
- The core idea is to approximate convolution likelihoods by "quasi-Poisson-like" functions. Then the updates are just summations of sufficient statistics for each incoming edge at each node.
- There's no numerical convolution required -- instead, everything is done with Laplace transforms (this requires evaluating hypergeometric functions, added `mpmath` as a dependency to do this as it seems to be much more stable numerically than `scipy`'s implementations)
- Some incoming features will be trickier to implement than for the discretized case (ancient samples, variable population size), but will still be possible I think
