### PR TITLE
Set metadata schemas

### DIFF
--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1838,7 +1838,7 @@ class TestNodeTimes:
 
     def test_fails_unconstrained(self):
         ts = utility_functions.two_tree_mutation_ts()
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="must be tsdated"):
             nodes_time_unconstrained(ts)
 
 
@@ -1852,9 +1852,14 @@ class TestSiteTimes:
         with pytest.raises(ValueError):
             tsdate.sites_time_from_ts(ts)
 
+    def test_undated(self):
+        ts = utility_functions.two_tree_mutation_ts()
+        with pytest.raises(ValueError, match="Try calling"):
+            tsdate.sites_time_from_ts(ts, unconstrained=True)
+
     def test_node_selection_param(self):
         ts = utility_functions.two_tree_mutation_ts()
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="node_selection parameter"):
             tsdate.sites_time_from_ts(ts, node_selection="sibling")
 
     def test_sites_time_insideoutside(self):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,303 @@
+# MIT License
+#
+# Copyright (c) 2021-23 Tskit Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+Test cases for metadata setting functionality in tsdate.
+"""
+import json
+import logging
+
+import numpy as np
+import pytest
+import tskit
+import utility_functions
+
+from tsdate.core import date
+from tsdate.metadata import node_md_struct
+from tsdate.metadata import save_node_metadata
+
+struct_obj_only_example = tskit.MetadataSchema(
+    {
+        "codec": "struct",
+        "type": "object",
+        "properties": {
+            "node_id": {"type": "integer", "binaryFormat": "i"},
+        },
+        "additionalProperties": False,
+    }
+)
+
+struct_bad_mn = tskit.MetadataSchema(
+    {
+        "codec": "struct",
+        "type": "object",
+        "properties": {
+            "mn": {"type": "integer", "binaryFormat": "i"},
+        },
+        "additionalProperties": False,
+    }
+)
+
+struct_bad_vr = tskit.MetadataSchema(
+    {
+        "codec": "struct",
+        "type": "object",
+        "properties": {
+            "vr": {"type": "string", "binaryFormat": "10p"},
+        },
+        "additionalProperties": False,
+    }
+)
+
+
+class TestBytes:
+    """
+    Tests for when existing node metadata is in raw bytes
+    """
+
+    def test_no_existing(self):
+        ts = utility_functions.single_tree_ts_n2()
+        root = ts.first().root
+        assert ts.node(root).metadata == b""
+        assert ts.table_metadata_schemas.node == tskit.MetadataSchema(None)
+        ts = date(ts, mutation_rate=1, population_size=1)
+        assert ts.node(root).metadata["mn"] == pytest.approx(ts.nodes_time[root])
+        assert ts.node(root).metadata["vr"] > 0
+
+    def test_append_existing(self):
+        ts = utility_functions.single_tree_ts_n2()
+        root = ts.first().root
+        assert ts.table_metadata_schemas.node == tskit.MetadataSchema(None)
+        tables = ts.dump_tables()
+        tables.nodes.clear()
+        for nd in ts.nodes():
+            tables.nodes.append(nd.replace(metadata=b'{"node_id": %d}' % nd.id))
+        ts = tables.tree_sequence()
+        assert json.loads(ts.node(root).metadata.decode())["node_id"] == root
+        ts = date(ts, mutation_rate=1, population_size=1)
+        assert ts.node(root).metadata["node_id"] == root
+        assert ts.node(root).metadata["mn"] == pytest.approx(ts.nodes_time[root])
+        assert ts.node(root).metadata["vr"] > 0
+
+    def test_replace_existing(self):
+        ts = utility_functions.single_tree_ts_n2()
+        root = ts.first().root
+        assert ts.table_metadata_schemas.node == tskit.MetadataSchema(None)
+        tables = ts.dump_tables()
+        tables.nodes.clear()
+        for nd in ts.nodes():
+            tables.nodes.append(nd.replace(metadata=b'{"mn": 1.0}'))
+        ts = tables.tree_sequence()
+        assert json.loads(ts.node(root).metadata.decode())["mn"] == pytest.approx(1.0)
+        ts = date(ts, mutation_rate=1, population_size=1)
+        assert ts.node(root).metadata["mn"] != pytest.approx(1.0)
+        assert ts.node(root).metadata["mn"] == pytest.approx(ts.nodes_time[root])
+        assert ts.node(root).metadata["vr"] > 0
+
+    def test_existing_bad(self):
+        ts = utility_functions.single_tree_ts_n2()
+        assert ts.table_metadata_schemas.node == tskit.MetadataSchema(None)
+        tables = ts.dump_tables()
+        tables.nodes.clear()
+        for nd in ts.nodes():
+            tables.nodes.append(nd.replace(metadata=b"!!"))
+        ts = tables.tree_sequence()
+        with pytest.raises(ValueError, match="Cannot modify"):
+            date(ts, mutation_rate=1, population_size=1)
+
+    def test_erase_existing_bad(self, caplog):
+        ts = utility_functions.single_tree_ts_n2()
+        root = ts.first().root
+        assert ts.table_metadata_schemas.node == tskit.MetadataSchema(None)
+        tables = ts.dump_tables()
+        tables.nodes.clear()
+        for nd in ts.nodes():
+            tables.nodes.append(nd.replace(metadata=b"!!"))
+        ts = tables.tree_sequence()
+        # Should be able to replace using set_metadat=True
+        with caplog.at_level(logging.WARNING):
+            ts = date(ts, mutation_rate=1, population_size=1, set_metadata=True)
+            assert "Erasing existing node metadata" in caplog.text
+        assert ts.table_metadata_schemas.node.schema["codec"] == "struct"
+        assert ts.node(root).metadata["mn"] == pytest.approx(ts.nodes_time[root])
+        assert ts.node(root).metadata["vr"] > 0
+
+
+class TestStruct:
+    """
+    Tests for when existing node metadata is as a struct
+    """
+
+    def test_append_existing(self):
+        ts = utility_functions.single_tree_ts_n2()
+        root = ts.first().root
+        tables = ts.dump_tables()
+        tables.nodes.metadata_schema = struct_obj_only_example
+        tables.nodes.packset_metadata(
+            [
+                tables.nodes.metadata_schema.validate_and_encode_row({"node_id": i})
+                for i in range(ts.num_nodes)
+            ]
+        )
+        ts = tables.tree_sequence()
+        assert ts.node(root).metadata["node_id"] == root
+        ts = date(ts, mutation_rate=1, population_size=1)
+        assert ts.node(root).metadata["node_id"] == root
+        assert ts.node(root).metadata["mn"] == pytest.approx(ts.nodes_time[root])
+        assert ts.node(root).metadata["vr"] > 0
+
+    def test_replace_existing(self, caplog):
+        ts = utility_functions.single_tree_ts_n2()
+        root = ts.first().root
+        tables = ts.dump_tables()
+        tables.nodes.metadata_schema = node_md_struct
+        tables.nodes.packset_metadata(
+            [
+                tables.nodes.metadata_schema.validate_and_encode_row(None)
+                for _ in range(ts.num_nodes)
+            ]
+        )
+        ts = tables.tree_sequence()
+        assert ts.node(root).metadata is None
+        with caplog.at_level(logging.INFO):
+            ts = date(ts, mutation_rate=1, population_size=1)
+            assert ts.table_metadata_schemas.node.schema["codec"] == "struct"
+            assert "Replacing 'mn'" in caplog.text
+            assert "Replacing 'vr'" in caplog.text
+            assert "Schema modified" in caplog.text
+            assert ts.node(root).metadata["mn"] == pytest.approx(ts.nodes_time[root])
+            assert ts.node(root).metadata["vr"] > 0
+            sample = ts.samples()[0]
+            assert ts.node(sample).metadata is None
+
+    def test_existing_bad_mn(self, caplog):
+        ts = utility_functions.single_tree_ts_n2()
+        tables = ts.dump_tables()
+        tables.nodes.metadata_schema = struct_bad_mn
+        tables.nodes.packset_metadata(
+            [
+                tables.nodes.metadata_schema.validate_and_encode_row({"mn": 1})
+                for _ in range(ts.num_nodes)
+            ]
+        )
+        ts = tables.tree_sequence()
+        with pytest.raises(
+            ValueError, match=r"Cannot change type of node.metadata\['mn'\]"
+        ):
+            date(ts, mutation_rate=1, population_size=1)
+
+    def test_existing_bad_vr(self, caplog):
+        ts = utility_functions.single_tree_ts_n2()
+        tables = ts.dump_tables()
+        tables.nodes.metadata_schema = struct_bad_vr
+        tables.nodes.packset_metadata(
+            [
+                tables.nodes.metadata_schema.validate_and_encode_row({"vr": "foo"})
+                for _ in range(ts.num_nodes)
+            ]
+        )
+        ts = tables.tree_sequence()
+        with pytest.raises(
+            ValueError, match=r"Cannot change type of node.metadata\['vr'\]"
+        ):
+            date(ts, mutation_rate=1, population_size=1)
+
+
+class TestJson:
+    """
+    Tests for when existing node metadata is json encoded
+    """
+
+    def test_replace_existing(self, caplog):
+        ts = utility_functions.single_tree_ts_n2()
+        root = ts.first().root
+        tables = ts.dump_tables()
+        schema = tables.nodes.metadata_schema = tskit.MetadataSchema.permissive_json()
+        tables.nodes.packset_metadata(
+            [
+                schema.validate_and_encode_row(
+                    {f"node {i}": 1, "mn": "foo", "vr": "bar"}
+                )
+                for i in range(ts.num_nodes)
+            ]
+        )
+        ts = tables.tree_sequence()
+        assert "node 0" in ts.node(0).metadata
+        assert ts.node(0).metadata["mn"] == "foo"
+        with caplog.at_level(logging.INFO):
+            ts = date(ts, mutation_rate=1, population_size=1)
+            assert ts.table_metadata_schemas.node.schema["codec"] == "json"
+            assert "Schema modified" in caplog.text
+            sample = ts.samples()[0]
+            assert f"node {sample}" in ts.node(sample).metadata
+            # Should have deleted mn and vr
+            assert "mn" not in ts.node(sample).metadata
+            assert "vr" not in ts.node(sample).metadata
+            assert f"node {root}" in ts.node(root).metadata
+            assert ts.node(root).metadata["mn"] == pytest.approx(ts.nodes_time[root])
+            assert ts.node(root).metadata["vr"] > 0
+
+
+class TestNoSetMetadata:
+    """
+    Tests for when metadata is not saved
+    """
+
+    @pytest.mark.parametrize(
+        "method", ["inside_outside", "maximization", "variational_gamma"]
+    )
+    def test_empty(self, method):
+        ts = utility_functions.single_tree_ts_n2()
+        assert len(ts.tables.nodes.metadata) == 0
+        ts = date(
+            ts, mutation_rate=1, population_size=1, method=method, set_metadata=False
+        )
+        assert len(ts.tables.nodes.metadata) == 0
+
+    @pytest.mark.parametrize(
+        "method", ["inside_outside", "maximization", "variational_gamma"]
+    )
+    def test_random_md(self, method):
+        ts = utility_functions.single_tree_ts_n2()
+        assert len(ts.tables.nodes.metadata) == 0
+        tables = ts.dump_tables()
+        tables.nodes.packset_metadata([(b"random %i" % u) for u in range(ts.num_nodes)])
+        ts = tables.tree_sequence()
+        assert len(ts.tables.nodes.metadata) > 0
+        dts = date(
+            ts, mutation_rate=1, population_size=1, method=method, set_metadata=False
+        )
+        assert len(ts.tables.nodes.metadata) == len(dts.tables.nodes.metadata)
+
+
+class TestFunctions:
+    """
+    Test internal metadata functions
+    """
+
+    def test_bad_save_node_metadata(self):
+        ts = utility_functions.single_tree_ts_n2()
+        bad_arr = np.zeros(ts.num_nodes + 1)
+        good_arr = np.zeros(ts.num_nodes)
+        for m, v in ([bad_arr, good_arr], [good_arr, bad_arr]):
+            with pytest.raises(ValueError, match="arrays of length ts.num_nodes"):
+                save_node_metadata(ts, m, v, fixed_node_set=set(ts.samples()))

--- a/tsdate/metadata.py
+++ b/tsdate/metadata.py
@@ -1,0 +1,173 @@
+# MIT License
+#
+# Copyright (c) 2023 Tskit Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+Functions for setting or merging schemas in tsdate-generated tree sequences. Note that
+tsdate will only add metadata to the node table, so this is the only relevant schema.
+"""
+import json
+import logging
+
+import tskit
+
+MEAN_KEY = "mn"
+VARIANCE_KEY = "vr"
+
+node_md_mean = {
+    "description": (
+        "The mean time of this node, calculated from the tsdate posterior "
+        "probabilities. This may not be the same as the node time, as it "
+        "is not constrained by parent-child order."
+    ),
+    "type": "number",
+    "binaryFormat": "d",
+}
+
+node_md_variance = {
+    "description": (
+        "The variance in times of this node, calculated from the tsdate "
+        "posterior probabilities"
+    ),
+    "type": "number",
+    "binaryFormat": "d",
+}
+
+node_md_struct = tskit.MetadataSchema(
+    {
+        "codec": "struct",
+        "type": ["object", "null"],
+        "default": None,
+        "properties": {MEAN_KEY: node_md_mean, VARIANCE_KEY: node_md_variance},
+        "additionalProperties": False,
+    }
+)
+
+
+def set_tsdate_node_md_schema(ts, set_metadata=None):
+    """
+    Taken from the ``tsdate.date()`` docs:
+        If set_metadata is ``True``, replace all existing node metadata with
+        details of the times (means and variances) for each node. If ``False``,
+        do not touch any existing metadata in the tree sequence. If ``None``
+        (default), attempt to modify any existing node metadata to add the
+        times (means and variances) for each node, overwriting only those specific
+        metadata values. If no node metadata schema has been set, this will be possible
+        only if either (a) the raw metadata can be decoded as JSON, in which case the
+        schema is set to permissive_json or (b) no node metadata exists (in which
+        case a default schema will be set), otherwise an error will be raised.
+
+    Returns:
+        A tuple of the tree sequence and a boolean indicating whether the
+        metadata should be saved or not.
+    """
+    if set_metadata is not None and not set_metadata:
+        logging.debug("Not setting node metadata")
+        return ts, False
+
+    tables = ts.dump_tables()
+    if set_metadata:
+        # Erase existing metadata, force schema to be node_md_struct
+        if len(tables.nodes.metadata) != 0:
+            logging.warning("Erasing existing node metadata")
+            tables.nodes.packset_metadata([b"" for _ in range(tables.nodes.num_rows)])
+        tables.nodes.metadata_schema = node_md_struct
+        return tables.tree_sequence(), True
+
+    # set_metadata is None: try to set or modify any existing metadata schema
+    schema_object = node_md_struct
+    if tables.nodes.metadata_schema == tskit.MetadataSchema(schema=None):
+        if len(tables.nodes.metadata) > 0:
+            # For backwards compatibility, if the node metadata is bytes (schema=None)
+            # but can be decoded as JSON, we change the schema to permissive_json
+            schema_object = tskit.MetadataSchema.permissive_json()
+            try:
+                for node in ts.nodes():
+                    _ = json.loads(node.metadata.decode() or "{}")
+            except json.JSONDecodeError:
+                raise ValueError(
+                    "Cannot modify node metadata if schema is "
+                    "None and non-JSON node metadata already exists"
+                )
+            logging.info("Null schema now set to permissive_json")
+    else:
+        # Make new schema on basis of existing
+        schema = tables.nodes.metadata_schema.schema
+        if "properties" not in schema:
+            schema["properties"] = {}
+        prop = schema["properties"]
+        for key, dfn in zip((MEAN_KEY, VARIANCE_KEY), (node_md_mean, node_md_variance)):
+            if key in prop:
+                if not prop[key].get("type") in {dfn["type"], None}:
+                    raise ValueError(
+                        f"Cannot change type of node.metadata['{key}'] in schema"
+                    )
+                else:
+                    logging.info(f"Replacing '{key}' in existing node metadata schema")
+
+            prop[key] = dfn.copy()
+            if schema["codec"] == "struct":
+                #  If we are adding to an existing struct codec, a "null" entry may
+                #  not be allowed, so we need to add null defaults for the new fields
+                logging.info("Adding NaN default to schema")
+                prop[key]["default"] = float("NaN")
+
+        # Repack, erasing old metadata present in the target keys
+        schema_object = tskit.MetadataSchema(schema)
+        metadata_array = []
+        for node in ts.nodes():
+            md = node.metadata
+            for key in [MEAN_KEY, VARIANCE_KEY]:
+                try:
+                    del md[key]
+                    logging.debug(f"Deleting existing '{key}' value in node metadata")
+                except (KeyError, TypeError):
+                    pass
+            metadata_array.append(schema_object.validate_and_encode_row(md))
+        tables.nodes.packset_metadata(metadata_array)
+        logging.info("Schema modified")
+
+    tables.nodes.metadata_schema = schema_object
+    return tables.tree_sequence(), True
+
+
+def save_node_metadata(ts, means, variances, fixed_node_set):
+    """
+    Assign means and variances (both arrays of length ts.num_nodes)
+    to the node metadata and return the resulting tree sequence.
+
+    Assumes that the metadata schema in the tree sequence allows
+    MEAN_KEY and VARIANCE_KEY to be set to numbers
+    """
+    if len(means) != ts.num_nodes or len(variances) != ts.num_nodes:
+        raise ValueError("means and variances must be arrays of length ts.num_nodes")
+    tables = ts.dump_tables()
+    nodes = tables.nodes
+    metadata_array = []
+    for node, mean, var in zip(ts.nodes(), means, variances):
+        md = node.metadata
+        if node.id not in fixed_node_set:
+            if md is None:
+                md = {}
+            md[MEAN_KEY] = mean
+            md[VARIANCE_KEY] = var
+        metadata_array.append(nodes.metadata_schema.validate_and_encode_row(md))
+    nodes.packset_metadata(metadata_array)
+    return tables.tree_sequence()


### PR DESCRIPTION
Defaults to a "struct" type unless a schema already exists (or if there is a null schema that can be interpreted as JSON). If so, the schema is modified to allow the mean time and variance in time (`mn` & `vr`) to be saved as extra values.

To maintain backwards-compatibility, I have used the top-level keys "mn" and "vr" for the mean and variance in times (the description field in the schema should make it clear what these are).

Fixes #302