### PR TITLE
Numeric fixes for extremely large shape parameters

### DIFF
--- a/tests/test_hypergeo.py
+++ b/tests/test_hypergeo.py
@@ -256,6 +256,12 @@ class TestTransforms:
             [1.62, 0.00074, 25603.8, 0.6653, 0.0, 0.0011],
             "Cancellation error in hypergeometric series",
         ],
+        # TODO: gives zero function value, but passes through dlmf1581
+        # [
+        #    hypergeo._hyp2f1_dlmf1583,
+        #    [9007.39, 0.241, 10000, 0.2673, 2.0, 0.01019],
+        #    "Cancellation error in hypergeometric series",
+        # ],
         [
             hypergeo._hyp2f1_dlmf1581,
             [1.62, 0.00074, 25603.8, 0.7653, 100.0, 0.0011],

--- a/tests/test_hypergeo.py
+++ b/tests/test_hypergeo.py
@@ -249,28 +249,28 @@ class TestTransforms:
         [
             hypergeo._hyp2f1_dlmf1583,
             [-21.62, 0.00074, 1003.8, 0.7653, 100.0, 0.0011],
-            "Cancellation error in hypergeometric polynomial",
+            "Cancellation error",
         ],
         [
             hypergeo._hyp2f1_dlmf1583,
             [1.62, 0.00074, 25603.8, 0.6653, 0.0, 0.0011],
-            "Cancellation error in hypergeometric series",
+            "Cancellation error",
         ],
         # TODO: gives zero function value, but passes through dlmf1581
         # [
         #    hypergeo._hyp2f1_dlmf1583,
         #    [9007.39, 0.241, 10000, 0.2673, 2.0, 0.01019],
-        #    "Cancellation error in hypergeometric series",
+        #    "Cancellation error",
         # ],
         [
             hypergeo._hyp2f1_dlmf1581,
             [1.62, 0.00074, 25603.8, 0.7653, 100.0, 0.0011],
-            "within maximum number of iterations",
+            "Maximum terms",
         ],
         [
             hypergeo._hyp2f1_dlmf1583,
             [1.0, 1.0, 1.0, 1.0, 3.0, 0.0],
-            "Zero division in hypergeometric polynomial",
+            "Zero division",
         ],
     ],
 )

--- a/tests/test_hypergeo.py
+++ b/tests/test_hypergeo.py
@@ -245,6 +245,7 @@ class TestTransforms:
         assert np.allclose(grad, check)
 
 
+# TODO: needs work
 @pytest.mark.parametrize(
     "pars",
     [
@@ -252,13 +253,14 @@ class TestTransforms:
         # [1.104, 0.0001125, 118.1396, 0.009052, 1.0, 0.001404],
         # [2.7481, 0.001221, 344.94083, 0.02329, 3.0, 0.00026624],
         [
-            -0.07565595034090222,
-            0.00015964167470460368,
-            229.5153349256595,
-            0.01209673063864175,
+            21.624020769312185,
+            0.0007429154579977896,
+            25603.81293768426,
+            0.7653563864917118,
             0.0,
-            2.414e-05,
-        ]
+            0.00108972,
+        ]  # jensen
+        # [ -0.07565595034090222, 0.00015964167470460368, 229.5153349256595, 0.01209673063864175, 0.0, 2.414e-05, ] # jensen
     ],
 )
 class TestSingular2F1:
@@ -269,8 +271,9 @@ class TestSingular2F1:
     """
 
     def test_dlmf1583_debug(self, pars):
-        print(hypergeo._hyp2f1_dlmf1581(*pars))
+        # print(hypergeo._hyp2f1_dlmf1581(*pars))
         print(hypergeo._hyp2f1_dlmf1583(*pars))
+        print(approx.mean_and_variance(*pars))
         print(approx.sufficient_statistics(*pars))
 
     def test_dlmf1583_throws_exception(self, pars):

--- a/tests/test_hypergeo.py
+++ b/tests/test_hypergeo.py
@@ -102,14 +102,15 @@ class TestTaylorSeries:
 
 @pytest.mark.parametrize(
     "pars",
-    list(
-        itertools.product(
-            [0.8, 20.3, 200.2],
-            [0.0, 1.0, 10.0, 51.0],
-            [1.6, 30.5, 300.7],
-            [1.1, 1.5, 1.9],
-        )
-    ),
+    [[0.13379589616147936, 1.0, 0.2675917923229587 - 0.13379589616147936, 2.0]]
+    # list(
+    #    itertools.product(
+    #        [0.8, 20.3, 200.2],
+    #        [0.0, 1.0, 10.0, 51.0],
+    #        [1.6, 30.5, 300.7],
+    #        [1.1, 1.5, 1.9],
+    #    )
+    # ),
 )
 class TestRecurrence:
     """
@@ -258,7 +259,7 @@ class TestSingular2F1:
     """
 
     def test_dlmf1583_throws_exception(self, pars):
-        with pytest.raises(Exception, match="is singular"):
+        with pytest.raises(Exception, match="did not converge"):
             hypergeo._hyp2f1_dlmf1583(*pars)
 
     def test_exception_uses_dlmf1581(self, pars):

--- a/tests/test_hypergeo.py
+++ b/tests/test_hypergeo.py
@@ -31,7 +31,6 @@ import numdifftools as nd
 import numpy as np
 import pytest
 
-from tsdate import approx
 from tsdate import hypergeo
 
 
@@ -104,15 +103,14 @@ class TestTaylorSeries:
 
 @pytest.mark.parametrize(
     "pars",
-    [[0.13379589616147936, 1.0, 0.2675917923229587 - 0.13379589616147936, 2.0]]
-    # list(
-    #    itertools.product(
-    #        [0.8, 20.3, 200.2],
-    #        [0.0, 1.0, 10.0, 51.0],
-    #        [1.6, 30.5, 300.7],
-    #        [1.1, 1.5, 1.9],
-    #    )
-    # ),
+    list(
+        itertools.product(
+            [0.8, 20.3, 200.2],
+            [0.0, 1.0, 10.0, 31.0],
+            [1.6, 30.5, 300.7],
+            [1.1, 1.5, 1.9, 4.2],
+        )
+    ),
 )
 class TestRecurrence:
     """
@@ -189,11 +187,11 @@ class TestCheckValid2F1:
 
     def test_is_valid_2f1(self, pars):
         dz, d2z = self._2f1(*pars)
-        assert hypergeo._is_valid_2f1(dz, d2z, *pars)
+        assert hypergeo._is_valid_2f1(dz, d2z, *pars, 1e-10)
         # perturb solution to differential equation
         dz *= 1 + 1e-3
         d2z *= 1 - 1e-3
-        assert not hypergeo._is_valid_2f1(dz, d2z, *pars)
+        assert not hypergeo._is_valid_2f1(dz, d2z, *pars, 1e-10)
 
 
 @pytest.mark.parametrize("muts", [0.0, 1.0, 5.0, 10.0])
@@ -245,42 +243,36 @@ class TestTransforms:
         assert np.allclose(grad, check)
 
 
-# TODO: needs work
 @pytest.mark.parametrize(
-    "pars",
+    "func, pars, err",
     [
-        # taken from examples in issues tsdate/286, tsdate/289
-        # [1.104, 0.0001125, 118.1396, 0.009052, 1.0, 0.001404],
-        # [2.7481, 0.001221, 344.94083, 0.02329, 3.0, 0.00026624],
         [
-            21.624020769312185,
-            0.0007429154579977896,
-            25603.81293768426,
-            0.7653563864917118,
-            0.0,
-            0.00108972,
-        ]  # jensen
-        # [ -0.07565595034090222, 0.00015964167470460368, 229.5153349256595, 0.01209673063864175, 0.0, 2.414e-05, ] # jensen
+            hypergeo._hyp2f1_dlmf1583,
+            [-21.62, 0.00074, 1003.8, 0.7653, 100.0, 0.0011],
+            "Cancellation error in hypergeometric polynomial",
+        ],
+        [
+            hypergeo._hyp2f1_dlmf1583,
+            [1.62, 0.00074, 25603.8, 0.6653, 0.0, 0.0011],
+            "Cancellation error in hypergeometric series",
+        ],
+        [
+            hypergeo._hyp2f1_dlmf1581,
+            [1.62, 0.00074, 25603.8, 0.7653, 100.0, 0.0011],
+            "within maximum number of iterations",
+        ],
+        [
+            hypergeo._hyp2f1_dlmf1583,
+            [1.0, 1.0, 1.0, 1.0, 3.0, 0.0],
+            "Zero division in hypergeometric polynomial",
+        ],
     ],
 )
-class TestSingular2F1:
+class TestInvalid2F1:
     """
-    Test detection of cases where 2F1 is close to singular and DLMF 15.8.3
-    suffers from catastrophic cancellation: in these cases, use DLMF 15.8.1
-    even though it takes much longer to converge.
+    Test cases where homegrown 2F1 fails to converge
     """
 
-    def test_dlmf1583_debug(self, pars):
-        # print(hypergeo._hyp2f1_dlmf1581(*pars))
-        print(hypergeo._hyp2f1_dlmf1583(*pars))
-        print(approx.mean_and_variance(*pars))
-        print(approx.sufficient_statistics(*pars))
-
-    def test_dlmf1583_throws_exception(self, pars):
-        with pytest.raises(Exception, match="did not converge"):
-            hypergeo._hyp2f1_dlmf1583(*pars)
-
-    def test_exception_uses_dlmf1581(self, pars):
-        v1, *_ = hypergeo._hyp2f1(*pars)
-        v2, *_ = hypergeo._hyp2f1_dlmf1581(*pars)
-        assert np.isclose(v1, v2)
+    def test_hyp2f1_error(self, func, pars, err):
+        with pytest.raises(hypergeo.Invalid2F1, match=err):
+            func(*pars)

--- a/tests/test_hypergeo.py
+++ b/tests/test_hypergeo.py
@@ -256,7 +256,7 @@ class TestTransforms:
             [1.62, 0.00074, 25603.8, 0.6653, 0.0, 0.0011],
             "Cancellation error",
         ],
-        # TODO: gives zero function value, but passes through dlmf1581
+        # TODO: gives zero function value, then reroutes through dlmf1581
         # [
         #    hypergeo._hyp2f1_dlmf1583,
         #    [9007.39, 0.241, 10000, 0.2673, 2.0, 0.01019],

--- a/tsdate/approx.py
+++ b/tsdate/approx.py
@@ -273,7 +273,7 @@ def gamma_projection(a_i, b_i, a_j, b_j, y_ij, mu_ij):
         )
         proj_i = approximate_gamma_kl(t_i, ln_t_i)
         proj_j = approximate_gamma_kl(t_j, ln_t_j)
-    except:  # noqa: E722,B001
+    except hypergeo.Invalid2F1:
         logconst, t_i, va_t_i, t_j, va_t_j = mean_and_variance(
             a_i, b_i, a_j, b_j, y_ij, mu_ij
         )

--- a/tsdate/approx.py
+++ b/tsdate/approx.py
@@ -176,6 +176,11 @@ def sufficient_statistics(a_i, b_i, a_j, b_j, y_ij, mu_ij):
     c = a_j + y_ij + 1
     t = mu_ij + b_i
 
+    assert a > 0
+    assert b > 0
+    assert c > 0
+    assert t > 0
+
     log_f, sign_f, da_i, db_i, da_j, db_j = hypergeo._hyp2f1(
         a_i, b_i, a_j, b_j, y_ij, mu_ij
     )
@@ -196,8 +201,11 @@ def sufficient_statistics(a_i, b_i, a_j, b_j, y_ij, mu_ij):
     )
 
     # check that Jensen's inequality holds
-    assert np.log(t_i) > ln_t_i
-    assert np.log(t_j) > ln_t_j
+    if not (np.log(t_i) > ln_t_i and np.log(t_j) > ln_t_j):
+        print([a_i, b_i, a_j, b_j, y_ij, mu_ij])
+        print(np.log(t_i), ln_t_i, np.log(t_j), ln_t_j)
+        print(logconst, da_i, db_i, da_j, db_j)
+        assert False, "bad bad bad!"
 
     return logconst, t_i, ln_t_i, t_j, ln_t_j
 

--- a/tsdate/core.py
+++ b/tsdate/core.py
@@ -1492,15 +1492,13 @@ def variational_dates(
     priors=None,
     *,
     max_iterations=20,
+    max_shape=None,
     global_prior=True,
     eps=1e-6,
     progress=False,
     num_threads=None,  # Unused, matches get_dates()
     probability_space=None,  # Can only be None, simply to match get_dates()
     ignore_oldest_root=False,  # Can only be False, simply to match get_dates()
-    debug_out=None,  # DEBUG
-    plot_subset=None,  # DEBUG
-    max_shape=None,  # DEBUG
 ):
     """
     Infer dates for the nodes in a tree sequence using expectation propagation,
@@ -1583,41 +1581,6 @@ def variational_dates(
         desc="Expectation Propagation",
     ):
         dynamic_prog.iterate(iter_num=it, max_shape=max_shape)
-        # DEBUG: track progress
-        if debug_out is not None:
-            _, mn, va = variational_mean_var(
-                tree_sequence, dynamic_prog.posterior, fixed_node_set=fixed_nodes
-            )
-            sh = mn**2 / va
-            # mn = constrain_ages_topo(tree_sequence, mn, eps, priors.nonfixed_nodes)
-            tr = tree_sequence.tables.nodes.time
-            if plot_subset is not None:
-                tr = tr[plot_subset]
-                mn = mn[plot_subset]
-                sh = sh[plot_subset]
-            else:
-                tr = tr[tree_sequence.num_samples :]
-                mn = mn[tree_sequence.num_samples :]
-                sh = sh[tree_sequence.num_samples :]
-            print(
-                "Iteration",
-                it,
-                "err",
-                np.mean(np.abs(mn - tr) / tr),
-                "max sh",
-                sh.max(),
-                flush=True,
-            )  # only meaningful when ts has true times
-            import matplotlib.pyplot as plt
-
-            pts = plt.scatter(tr, mn, s=2, c=sh, cmap="plasma")
-            plt.colorbar(pts)
-            plt.axline((0, 0), slope=1, c="black")
-            plt.xlabel("Level order")
-            plt.ylabel("Inferred time")
-            plt.title(f"Iteration {it}")
-            plt.savefig(f"{debug_out}.{it:05}.png")
-            plt.clf()
 
     posterior = dynamic_prog.posterior
     tree_sequence, mn_post, _ = variational_mean_var(

--- a/tsdate/core.py
+++ b/tsdate/core.py
@@ -1085,7 +1085,12 @@ class ExpectationPropagation(InOutAlgorithms):
         for desc, func in tqdm(
             tasks.items(), f"Iteration {it}", disable=not progress, leave=False
         ):
-            self.propagate(edges=func(grouped=False), desc=desc, progress=progress)
+            self.propagate(
+                edges=func(grouped=False),
+                desc=desc,
+                progress=progress,
+                max_shape=max_shape,
+            )
 
         # TODO
         # marginal_lik = np.sum(self.factor_norm)

--- a/tsdate/core.py
+++ b/tsdate/core.py
@@ -1062,7 +1062,7 @@ class ExpectationPropagation(InOutAlgorithms):
                         self.posterior[node],
                         self.child_message[edges_out],
                         self.parent_message[edges_in],
-                        new_shape=max_shape,
+                        max_shape,
                     )
 
             # Get the contribution to the (approximate) marginal likelihood from

--- a/tsdate/hypergeo.py
+++ b/tsdate/hypergeo.py
@@ -199,7 +199,8 @@ def _hyp2f1_taylor_series(a, b, c, z):
         val = np.log(val) + offset
         if k >= _HYP2F1_MAXTERM:
             raise Invalid2F1(
-                "Hypergeometric series did not converge within maximum number of iterations"
+                "Hypergeometric series did not converge within "
+                "maximum number of iterations"
             )
     return val, sign, da, db, dc, dz, d2z
 
@@ -217,14 +218,13 @@ def _hyp2f1_recurrence(a, b, c, z):
     occurs if `z == c / a`).
     """
     assert b % 1.0 == 0.0 and b >= 0
-    # assert np.abs(c) >= np.abs(a)
     assert z > 1.0
     f0 = 1.0
     f1 = 1 - a * z / c
     s0 = 1.0
     s1 = np.sign(f1)
     if s1 == 0:
-        raise Invalid2F1("Zero division in hypergeometric recurrence")
+        raise Invalid2F1("Zero division in hypergeometric polynomial")
     g0 = np.zeros(4)  # df/da df/db df/dc df/dz
     g1 = np.array([-z / c, 0.0, a * z / c**2, -a / c]) / f1
     p0 = 0.0  # d2f/dz2
@@ -244,7 +244,7 @@ def _hyp2f1_recurrence(a, b, c, z):
         v = s1 * bk + u * ak
         s = np.sign(v)
         if s == 0:
-            raise Invalid2F1("Zero division in hypergeometric recurrence")
+            raise Invalid2F1("Zero division in hypergeometric polynomial")
         f = np.log(np.abs(v)) + f1
         g = (g1 * bk * s1 + g0 * u * ak + dbk * s1 + dak * u) / v
         p = (
@@ -257,7 +257,7 @@ def _hyp2f1_recurrence(a, b, c, z):
         g1, g0 = g, g1
         p1, p0 = p, p1
     if not _is_valid_2f1(g[3], p, a, -b, c, z, _HYP2F1_TOL):
-        raise Invalid2F1("Hypergeometric series did not converge")
+        raise Invalid2F1("Cancellation error in hypergeometric polynomial")
     da, db, dc, dz = g
     return f, s, da, db, dc, dz, p
 
@@ -437,10 +437,9 @@ def _hyp2f1_dlmf1583(a_i, b_i, a_j, b_j, y, mu):
     dz = -db_j * (mu + b_i)
     d2z = d2b_j * (mu + b_i) ** 2
     if not _is_valid_2f1(dz, d2z, a, b, c, z, _HYP2F1_TOL):
-        # use Pfaff transform if argument is not close to unity
-        if z / (z - 1) < 0.9:
+        if z / (z - 1) < 0.9:  # use Pfaff transform for small enough argument
             return _hyp2f1_dlmf1581(a_i, b_i, a_j, b_j, y, mu)
-        raise Invalid2F1("Hypergeometric series did not converge")
+        raise Invalid2F1("Cancellation error in hypergeometric series")
 
     sign = np.sign(f)
     val = np.log(np.abs(f)) + f_0 + scale

--- a/tsdate/hypergeo.py
+++ b/tsdate/hypergeo.py
@@ -183,7 +183,7 @@ def _hyp2f1_taylor_series(a, b, c, z):
                 d2z = iz * (iz - 1 / z) + d2z / norm
                 offset = weight
             if not np.isfinite(val):
-                raise Invalid2F1("Hypergeometric series did not converge")
+                raise Invalid2F1("Nonfinite function value in hypergeometric series")
             if weight < ltol + np.log(val) and _is_valid_2f1(
                 dz / val, d2z / val, a, b, c, z, _HYP2F1_TOL
             ):
@@ -198,7 +198,9 @@ def _hyp2f1_taylor_series(a, b, c, z):
         sign = 1.0
         val = np.log(val) + offset
         if k >= _HYP2F1_MAXTERM:
-            raise Invalid2F1("Hypergeometric series did not converge")
+            raise Invalid2F1(
+                "Hypergeometric series did not converge within maximum number of iterations"
+            )
     return val, sign, da, db, dc, dz, d2z
 
 
@@ -382,8 +384,6 @@ def _hyp2f1_dlmf1583_second(a_i, b_i, a_j, b_j, y, mu):
 
     sign *= (-1) ** (y + 1)
     val += scale
-
-    print(np.log(1 - s), dc, _digamma(a_i))  # DEBUG
 
     return val, sign, da_i, db_i, da_j, db_j, d2b_j
 

--- a/tsdate/hypergeo.py
+++ b/tsdate/hypergeo.py
@@ -417,6 +417,11 @@ def _hyp2f1_dlmf1583(a_i, b_i, a_j, b_j, y, mu):
     f_2 = np.exp(f_2 - f_0) * s_2
     f = f_1 + f_2
 
+    if f <= 0.0:
+        if z / (z - 1) < 0.9:  # use Pfaff transform for small enough argument
+            return _hyp2f1_dlmf1581(a_i, b_i, a_j, b_j, y, mu)
+        raise Invalid2F1("Cancellation error in hypergeometric series")
+
     da_i = (da_i_1 * f_1 + da_i_2 * f_2) / f
     db_i = (db_i_1 * f_1 + db_i_2 * f_2) / f
     da_j = (da_j_1 * f_1 + da_j_2 * f_2) / f

--- a/tsdate/hypergeo.py
+++ b/tsdate/hypergeo.py
@@ -57,7 +57,7 @@ def _digamma(x):
     Digamma (psi) function, from asymptotic series expansion.
     """
     if x <= 0.0:
-        return np.nan
+        return _digamma(1 - x) - np.pi / np.tan(np.pi * x)
     if x <= 1e-5:
         return -np.euler_gamma - (1 / x)
     if x < 8.5:
@@ -81,7 +81,7 @@ def _trigamma(x):
     Trigamma function, from asymptotic series expansion
     """
     if x <= 0.0:
-        return np.nan
+        return -_trigamma(1 - x) + np.pi**2 / np.sin(np.pi * x) ** 2
     if x <= 1e-4:
         return 1 / x**2
     if x < 5:
@@ -215,7 +215,7 @@ def _hyp2f1_recurrence(a, b, c, z):
     occurs if `z == c / a`).
     """
     assert b % 1.0 == 0.0 and b >= 0
-    assert np.abs(c) >= np.abs(a)
+    # assert np.abs(c) >= np.abs(a)
     assert z > 1.0
     f0 = 1.0
     f1 = 1 - a * z / c
@@ -382,6 +382,8 @@ def _hyp2f1_dlmf1583_second(a_i, b_i, a_j, b_j, y, mu):
 
     sign *= (-1) ** (y + 1)
     val += scale
+
+    print(np.log(1 - s), dc, _digamma(a_i))  # DEBUG
 
     return val, sign, da_i, db_i, da_j, db_j, d2b_j
 

--- a/tsdate/hypergeo.py
+++ b/tsdate/hypergeo.py
@@ -435,8 +435,8 @@ def _hyp2f1_dlmf1583(a_i, b_i, a_j, b_j, y, mu):
     dz = -db_j * (mu + b_i)
     d2z = d2b_j * (mu + b_i) ** 2
     if not _is_valid_2f1(dz, d2z, a, b, c, z, _HYP2F1_TOL):
-        # if argument is not close to unity, use direct expansion
-        if z < 0.9:
+        # use Pfaff transform if argument is not close to unity
+        if z / (z - 1) < 0.9:
             return _hyp2f1_dlmf1581(a_i, b_i, a_j, b_j, y, mu)
         raise Invalid2F1("Hypergeometric series did not converge")
 

--- a/tsdate/hypergeo.py
+++ b/tsdate/hypergeo.py
@@ -269,7 +269,7 @@ def _hyp2f1_dlmf1581(a_i, b_i, a_j, b_j, y, mu):
     """
     DLMF 15.8.1, series expansion with Pfaff transformation
     """
-    assert b_i >= 0
+    # assert b_i >= 0
     assert 0 <= mu <= b_j
     assert y >= 0 and y % 1 == 0.0
 
@@ -395,7 +395,7 @@ def _hyp2f1_dlmf1583(a_i, b_i, a_j, b_j, y, mu):
     """
     DLMF 15.8.3, sum of recurrence and series expansion
     """
-    assert b_i >= 0
+    # assert b_i >= 0
     assert 0 <= mu <= b_j
     assert y >= 0 and y % 1.0 == 0.0
 
@@ -459,7 +459,7 @@ def _hyp2f1_dlmf1521(a_i, b_i, a_j, b_j, y, mu):
     """
     DLMF 15.2.1, series expansion without transformation
     """
-    assert b_i >= 0
+    # assert b_i >= 0
     assert mu >= b_j >= 0
     assert y >= 0 and y % 1 == 0.0
 


### PR DESCRIPTION
- A bit better handling of cancellation error in custom 2F1
- Use high-precision mpmath.hyp2f1 to match mean and variance as a failsafe
- Project approximations with large shape parameters (threshold set by `max_shape`) to a predetermined value of the shape parameter. 

The cap on the shape parameter basically says, "this approximation is extremely precise, but we'll only let it get *this* precise so that the distribution doesn't degenerate". This is akin to setting a minimum variance, except that the shape parameterization is scale invariant. By default, `max_shape` should be None, because if the shape parameters do get extremely large (e.g. the approximation degenerates) then that tells us that there's some inconsistency in the topology that makes dating difficult. For example, this can occur when there are unary nodes from tsinfer that span nearly the entire tree sequence (e.g. all root nodes would have to be older than these "global" unary nodes) which introduce very unnatural constraints. However, for debugging purposes it's nice to be able to cap the gamma shape so the program doesn't error out.