### PR TITLE
Faster prior variance calculation

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -37,7 +37,7 @@ class TestSetCacheDir(unittest.TestCase):
         priors_approxNone.add(10)
         assert np.allclose(priors_approx10[10], priors_approxNone[10], equal_nan=True)
         # Test when using a bigger n that we're using the precalculated version
-        priors_approx10.add(100)
+        priors_approx10.add(100, approximate=True)
         assert priors_approx10[100].shape[0] == 100 + 1
         priors_approxNone.add(100, approximate=False)
         assert priors_approxNone[100].shape[0] == 100 + 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -253,7 +253,6 @@ class TestOutput(RunCLI):
         desc = (
             "Find Node Spans",
             "TipCount",
-            "Calculating Node Age Variances",
             "Find Mixture Priors",
             "Inside",
             "Outside",

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -63,28 +63,14 @@ class TestBasicFunctions:
     Test for some of the basic functions used in tsdate
     """
 
-    def test_alpha_prob(self):
-        assert ConditionalCoalescentTimes.m_prob(2, 2, 3) == 1.0
-        assert ConditionalCoalescentTimes.m_prob(2, 2, 4) == 0.25
-
     def test_tau_expect(self):
         assert ConditionalCoalescentTimes.tau_expect(10, 10) == 1.8
         assert ConditionalCoalescentTimes.tau_expect(10, 100) == 0.09
         assert ConditionalCoalescentTimes.tau_expect(100, 100) == 1.98
         assert ConditionalCoalescentTimes.tau_expect(5, 10) == 0.4
 
-    def test_tau_squared_conditional(self):
-        assert ConditionalCoalescentTimes.tau_squared_conditional(
-            1, 10
-        ) == pytest.approx(4.3981418)
-        assert ConditionalCoalescentTimes.tau_squared_conditional(
-            100, 100
-        ) == pytest.approx(4.87890977e-18)
-
-    def test_tau_var(self):
-        assert ConditionalCoalescentTimes.tau_var(2, 2) == 1
-        assert ConditionalCoalescentTimes.tau_var(10, 20) == pytest.approx(0.0922995960)
-        assert ConditionalCoalescentTimes.tau_var(50, 50) == pytest.approx(1.15946186)
+    def test_tau_var_mrca(self):
+        assert np.isclose(ConditionalCoalescentTimes.tau_var_mrca(50), 1.15946186)
 
     def test_gamma_approx(self):
         assert gamma_approx(2, 1) == (4.0, 2.0)
@@ -1880,7 +1866,9 @@ class TestSiteTimes:
     def test_sites_time_insideoutside(self):
         ts = utility_functions.two_tree_mutation_ts()
         dated = tsdate.date(ts, mutation_rate=None, population_size=1)
-        _, mn_post, _, _, eps, _, _ = get_dates(ts, mutation_rate=None, population_size=1)
+        _, mn_post, _, _, eps, _, _ = get_dates(
+            ts, mutation_rate=None, population_size=1
+        )
         assert np.array_equal(
             mn_post[ts.tables.mutations.node],
             tsdate.sites_time_from_ts(dated, unconstrained=True, min_time=0),

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -138,3 +138,26 @@ class TestTimepoints:
         priors.prior_distr = "bad_distr"
         with pytest.raises(ValueError, match="must be lognorm or gamma"):
             create_timepoints(priors, n_points=3)
+
+
+class TestUtilityFunctions:
+    def test_m_prob(self):
+        assert utility_functions.m_prob(2, 2, 3) == 1.0
+        assert utility_functions.m_prob(2, 2, 4) == 0.25
+
+    def test_tau_expect(self):
+        assert utility_functions.tau_expect(10, 10) == 1.8
+        assert utility_functions.tau_expect(10, 100) == 0.09
+        assert utility_functions.tau_expect(100, 100) == 1.98
+        assert utility_functions.tau_expect(5, 10) == 0.4
+
+    def test_tau_squared_conditional(self):
+        assert np.isclose(utility_functions.tau_squared_conditional(1, 10), 4.3981418)
+        assert np.isclose(
+            utility_functions.tau_squared_conditional(100, 100), 4.87890977e-18
+        )
+
+    def test_tau_var(self):
+        assert utility_functions.tau_var(2, 2) == 1
+        assert np.isclose(utility_functions.tau_var(10, 20), 0.0922995960)
+        assert np.isclose(utility_functions.tau_var(50, 50), 1.15946186)

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -28,6 +28,7 @@ import numpy as np
 import pytest
 import utility_functions
 
+from tsdate.prior import conditional_coalescent_variance
 from tsdate.prior import ConditionalCoalescentTimes
 from tsdate.prior import create_timepoints
 from tsdate.prior import PriorParams
@@ -73,8 +74,8 @@ class TestConditionalCoalescentTimes:
         mean2, var2 = priors.mixture_expect_and_var(params, weight_by_log_span=logwt)
         assert mean1 == pytest.approx(1 / 3)  # 1/N for a cherry
         assert var1 == pytest.approx(1 / 9)
-        assert mean1 == mean2
-        assert var1 == var2
+        assert np.isclose(mean1, mean2)
+        assert np.isclose(var1, var2)
 
     def test_mixture_expect_and_var_weight(self):
         priors = ConditionalCoalescentTimes(None)
@@ -99,6 +100,12 @@ class TestConditionalCoalescentTimes:
         }
         logwt = priors.mixture_expect_and_var(params, weight_by_log_span=True)
         assert np.allclose(linwt, logwt)
+
+    def test_fast_equals_naive(self):
+        # test fast recursion against slow but clearly correct version
+        true = utility_functions.conditional_coalescent_variance(100)
+        test = conditional_coalescent_variance(100)
+        np.testing.assert_array_almost_equal(true, test)
 
 
 class TestSpansBySamples:

--- a/tests/utility_functions.py
+++ b/tests/utility_functions.py
@@ -1028,59 +1028,49 @@ def truncate_ts_samples(ts, average_span, random_seed, min_span=5):
     )
 
 
+def m_prob(m, i, n):
+    """
+    Corollary 2 in Wiuf and Donnelly (1999). Probability of one
+    ancestor to entire sample at time tau
+    """
+    return (comb(n - m - 1, i - 2, exact=True) * comb(m, 2, exact=True)) / comb(
+        n, i + 1, exact=True
+    )
+
+
+def tau_expect(i, n):
+    if i == n:
+        return 2 * (1 - (1 / n))
+    else:
+        return (i - 1) / n
+
+
+def tau_squared_conditional(m, n):
+    """
+    Gives expectation of tau squared conditional on m
+    Equation (10) from Wiuf and Donnelly (1999).
+    """
+    t_sum = np.sum(1 / np.arange(m, n + 1) ** 2)
+    return 8 * t_sum + (8 / n) - (8 / m) - (8 / (n * m))
+
+
+def tau_var(i, n):
+    """
+    For the last coalesence (n=2), calculate the Tmrca of the whole sample
+    """
+    if i == n:
+        value = np.arange(2, n + 1)
+        var = np.sum(1 / ((value**2) * ((value - 1) ** 2)))
+        return np.abs(4 * var)
+    elif i == 0:
+        return 0.0
+    else:
+        tau_square_sum = 0
+        for m in range(2, n - i + 2):
+            tau_square_sum += m_prob(m, i, n) * tau_squared_conditional(m, n)
+        return np.abs((tau_expect(i, n) ** 2) - (tau_square_sum))
+
+
 def conditional_coalescent_variance(n_tips):
-    # Variance calculation for prior, slow but clear version
-
-    def m_prob(m, i, n):
-        """
-        Corollary 2 in Wiuf and Donnelly (1999). Probability of one
-        ancestor to entire sample at time tau
-        """
-        return (comb(n - m - 1, i - 2, exact=True) * comb(m, 2, exact=True)) / comb(
-            n, i + 1, exact=True
-        )
-
-    def tau_expect(i, n):
-        if i == n:
-            return 2 * (1 - (1 / n))
-        else:
-            return (i - 1) / n
-
-    def tau_squared_conditional(m, n):
-        """
-        Gives expectation of tau squared conditional on m
-        Equation (10) from Wiuf and Donnelly (1999).
-        """
-        t_sum = np.sum(1 / np.arange(m, n + 1) ** 2)
-        return 8 * t_sum + (8 / n) - (8 / m) - (8 / (n * m))
-
-    def tau_var(i, n):
-        """
-        For the last coalesence (n=2), calculate the Tmrca of the whole sample
-        """
-        if i == n:
-            value = np.arange(2, n + 1)
-            var = np.sum(1 / ((value**2) * ((value - 1) ** 2)))
-            return np.abs(4 * var)
-        elif i == 0:
-            return 0.0
-        else:
-            tau_square_sum = 0
-            for m in range(2, n - i + 2):
-                tau_square_sum += m_prob(m, i, n) * tau_squared_conditional(m, n)
-            return np.abs((tau_expect(i, n) ** 2) - (tau_square_sum))
-
-    # point checks originally from test suite
-    assert m_prob(2, 2, 3) == 1.0
-    assert m_prob(2, 2, 4) == 0.25
-    assert tau_expect(10, 10) == 1.8
-    assert tau_expect(10, 100) == 0.09
-    assert tau_expect(100, 100) == 1.98
-    assert tau_expect(5, 10) == 0.4
-    assert np.isclose(tau_squared_conditional(1, 10), 4.3981418)
-    assert np.isclose(tau_squared_conditional(100, 100), 4.87890977e-18)
-    assert tau_var(2, 2) == 1
-    assert np.isclose(tau_var(10, 20), 0.0922995960)
-    assert np.isclose(tau_var(50, 50), 1.15946186)
-
+    """Variance calculation for prior, slow but clear version"""
     return np.array([tau_var(i, n_tips) for i in range(n_tips + 1)])

--- a/tsdate/core.py
+++ b/tsdate/core.py
@@ -1398,9 +1398,9 @@ def get_dates(
             raise NotImplementedError("Samples must all be at time 0")
     fixed_nodes = set(tree_sequence.samples())
 
-    # Default to not creating approximate priors unless ts has > 1000 samples
+    # Default to not creating approximate priors unless ts has > 20000 samples
     approx_priors = False
-    if tree_sequence.num_samples > 1000:
+    if tree_sequence.num_samples > 20000:
         approx_priors = True
 
     if priors is None:
@@ -1584,9 +1584,9 @@ def variational_dates(
             "Ignoring the oldes root is not implemented in variational dating"
         )
 
-    # Default to not creating approximate priors unless ts has > 1000 samples
+    # Default to not creating approximate priors unless ts has > 20000 samples
     approx_priors = False
-    if tree_sequence.num_samples > 1000:
+    if tree_sequence.num_samples > 20000:
         approx_priors = True
 
     if priors is None:

--- a/tsdate/demography.py
+++ b/tsdate/demography.py
@@ -165,6 +165,8 @@ class PopulationSizeHistory:
         )
         return coalescent_time_ago
 
+    # TODO: multiprecision implementation -- remove at some point
+
     # @staticmethod
     # def _Gamma(z, a=0, b=np.inf):
     #    """

--- a/tsdate/prior.py
+++ b/tsdate/prior.py
@@ -181,7 +181,6 @@ class ConditionalCoalescentTimes:
     def prior_with_max_total_tips(self):
         return self.prior_store.get(max(self.prior_store.keys()))
 
-    # TODO: remove old variance calculation
     def add(self, total_tips, approximate=None):
         """
         Create and store a numpy array used to lookup prior params and mean + variance
@@ -285,6 +284,12 @@ class ConditionalCoalescentTimes:
         else:
             return (i - 1) / n
 
+    @staticmethod
+    def tau_var_mrca(n):
+        value = np.arange(2, n + 1)
+        var = np.sum(1 / ((value**2) * ((value - 1) ** 2)))
+        return np.abs(4 * var)
+
     # The following are not static as they may need to access self.approx_priors for this
     # instance
     def tau_var_lookup(self, total_tips, all_tips):
@@ -300,9 +305,7 @@ class ConditionalCoalescentTimes:
         # interpolated_priors = self.approx_priors[insertion_point, 1]
 
         # The final MRCA we calculate exactly
-        interpolated_priors[all_tips == total_tips] = self.tau_var(
-            total_tips, total_tips
-        )
+        interpolated_priors[all_tips == total_tips] = self.tau_var_mrca(total_tips)
         return interpolated_priors
 
     def tau_var_exact(self, total_tips, all_tips):

--- a/tsdate/prior.py
+++ b/tsdate/prior.py
@@ -193,7 +193,7 @@ class ConditionalCoalescentTimes:
         if approximate is not None:
             self.approximate = approximate
         else:
-            if total_tips >= 20000:
+            if total_tips >= 10000:
                 self.approximate = True
             else:
                 self.approximate = False
@@ -202,6 +202,12 @@ class ConditionalCoalescentTimes:
             raise RuntimeError(
                 "You cannot add an approximate prior unless you initialize"
                 " the ConditionalCoalescentTimes object with a non-zero number"
+            )
+
+        if not self.approximate and total_tips >= 10000:
+            logging.warning(
+                "Calculating exact priors for more than 10000 tips. Consider "
+                "setting `approximate=True` for a faster calculation."
             )
 
         # alpha/beta and mean/var are simply transformations of one another
@@ -1056,7 +1062,7 @@ class MixturePrior:
 
         if approximate_priors:
             if not approx_prior_size:
-                approx_prior_size = 1000
+                approx_prior_size = 10000
         else:
             if approx_prior_size is not None:
                 raise ValueError(


### PR DESCRIPTION
Use a recursive approach to calculating prior variances that is a couple of orders of magnitude faster:

<img src="https://github.com/tskit-dev/tsdate/assets/5767783/4c42ce7a-b6e4-4534-8ac9-b20f57c2be6b" width="40%">

so it's possible to get the exact variances for 100,000 tips in a few minutes (by comparison, it's infeasible to get exact variances for more than 2,000 tips or so with the original algorithm). 

Some indication that the two algorithms are equivalent, showing sqrt(variance) for 1280 tips:

<img src="https://github.com/tskit-dev/tsdate/assets/5767783/2ce083ec-7052-4519-9031-ccec43e057f8" width="40%">

Still trying to get my head around the interpolation scheme used for the approximation, and if this algorithm will be useful there (it recurses backwards from the maximum number of tips).
