### PR TITLE
Fix excess mutation count at last edge (closes #308)

### DIFF
--- a/tsdate/core.py
+++ b/tsdate/core.py
@@ -130,7 +130,8 @@ class Likelihoods:
         """
         mut_edges = np.zeros(ts.num_edges, dtype=np.int64)
         for m in ts.mutations():
-            mut_edges[m.edge] += 1
+            if m.edge != tskit.NULL:
+                mut_edges[m.edge] += 1
         return mut_edges
 
     @staticmethod


### PR DESCRIPTION
Fix minor bug where unmapped mutations are assigned to the last edge by `Likelihoods`, causing a single large outlier when dating