### PR TITLE
Set number for approx using a constant

### DIFF
--- a/tsdate/base.py
+++ b/tsdate/base.py
@@ -29,7 +29,7 @@ FLOAT_DTYPE = np.float64
 LIN = "linear"
 LOG = "logarithmic"
 GAMMA_PAR = "gamma_parameter"
-
+NTIPS_DEFAULT_PRIOR_APPROX = 10000  # n_tips above which to use an approx for the prior
 # Bit 20 is set in node flags when they are samples not at time zero in the sampledata
 # file
 NODE_IS_HISTORIC_SAMPLE = 1 << 20

--- a/tsdate/cli.py
+++ b/tsdate/cli.py
@@ -192,7 +192,7 @@ def tsdate_cli_parser():
         "--verbosity",
         action="count",
         default=0,
-        help="How much verbosity to output.",
+        help="How much verbosity to output (max is -vv).",
     )
     parser.set_defaults(runner=run_preprocess)
     return top_parser

--- a/tsdate/core.py
+++ b/tsdate/core.py
@@ -1602,9 +1602,10 @@ def variational_dates(
             "Ignoring the oldes root is not implemented in variational dating"
         )
 
-    # Default to not creating approximate priors unless ts has > 20000 samples
+    # Default to not creating approximate priors unless ts has
+    # greater than NTIPS_DEFAULT_PRIOR_APPROX samples
     approx_priors = False
-    if tree_sequence.num_samples > 20000:
+    if tree_sequence.num_samples > base.NTIPS_DEFAULT_PRIOR_APPROX:
         approx_priors = True
 
     if priors is None:

--- a/tsdate/prior.py
+++ b/tsdate/prior.py
@@ -193,7 +193,7 @@ class ConditionalCoalescentTimes:
         if approximate is not None:
             self.approximate = approximate
         else:
-            if total_tips >= 10000:
+            if total_tips >= base.NTIPS_DEFAULT_PRIOR_APPROX:
                 self.approximate = True
             else:
                 self.approximate = False
@@ -204,9 +204,10 @@ class ConditionalCoalescentTimes:
                 " the ConditionalCoalescentTimes object with a non-zero number"
             )
 
-        if not self.approximate and total_tips >= 10000:
+        if not self.approximate and total_tips >= base.NTIPS_DEFAULT_PRIOR_APPROX:
             logging.warning(
-                "Calculating exact priors for more than 10000 tips. Consider "
+                "Calculating exact priors for more than "
+                f"{base.NTIPS_DEFAULT_PRIOR_APPROX} tips. Consider "
                 "setting `approximate=True` for a faster calculation."
             )
 
@@ -480,7 +481,8 @@ class SpansBySamples:
         if not allow_unary:
             if has_locally_unary_nodes(self.ts):
                 raise ValueError(
-                    "The input tree sequence has unary nodes: tsdate currently requires that these are removed using `simplify(keep_unary=False)`"
+                    "The input tree sequence has unary nodes: tsdate currently requires "
+                    "that these are removed using `simplify(keep_unary=False)`"
                 )
 
         with tqdm(total=3, desc="TipCount", disable=not self.progress) as progressbar:
@@ -1067,7 +1069,7 @@ class MixturePrior:
     ):
         if approximate_priors:
             if not approx_prior_size:
-                approx_prior_size = 10000
+                approx_prior_size = base.NTIPS_DEFAULT_PRIOR_APPROX
         else:
             if approx_prior_size is not None:
                 raise ValueError(


### PR DESCRIPTION
Previously the numbers in prior.py and core.py did not match, so warnings were output unnecessarily 