### PR TITLE
Minor fixes for central moment matching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ tqdm
 daiquiri
 msprime>=1.0.0
 scipy
-numba
+numba>=0.58.0
 appdirs
 pre-commit
 pytest

--- a/tests/test_hypergeo.py
+++ b/tests/test_hypergeo.py
@@ -78,8 +78,14 @@ class TestLaplaceApprox:
 
     def test_2f1(self, a_i, b_i, a_j, b_j, y, mu):
         pars = [a_i, b_i, a_j, b_j, y, mu]
+        A = a_j
+        B = a_i + a_j + y
+        C = a_j + y + 1
+        z = (mu - b_j) / (mu + b_i)
         f, *_ = hypergeo._hyp2f1(*pars)
+        ff = hypergeo._hyp2f1_fast(A, B, C, z)
         check = float(mpmath.log(self._2f1_validate(*pars)))
+        assert np.isclose(f, ff)
         assert np.isclose(f, check, rtol=2e-2)
 
     def test_grad(self, a_i, b_i, a_j, b_j, y, mu):

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -427,3 +427,21 @@ class TestVariational:
                 method="variational_gamma",
                 max_iterations=-1,
             )
+
+    def test_match_central_moments(self):
+        ts = msprime.simulate(8, mutation_rate=5, recombination_rate=5, random_seed=2)
+        ts0 = tsdate.date(
+            ts,
+            mutation_rate=5,
+            population_size=1,
+            method="variational_gamma",
+            method_of_moments=False,
+        )
+        ts1 = tsdate.date(
+            ts,
+            mutation_rate=5,
+            population_size=1,
+            method="variational_gamma",
+            method_of_moments=True,
+        )
+        assert np.any(np.not_equal(ts0.nodes_time, ts1.nodes_time))

--- a/tsdate/approx.py
+++ b/tsdate/approx.py
@@ -244,11 +244,12 @@ def _valid_parameterization(a_i, b_i, a_j, b_j, y, mu):
     s = mu - b_j
     t = mu + b_i
     # check that 2F1 argument is not unity under some transformation
-    if np.isclose(t, 0.0):
+    if t <= 0.0:
         return False
-    if np.isclose(s / t, 1.0):
+    z = s / t
+    if z >= 1.0:
         return False
-    if np.isclose(-s / (t - s), 1.0):
+    if z / (z - 1) >= 1.0:
         return False
     # check that 2F1 is positive
     if a <= 0:

--- a/tsdate/core.py
+++ b/tsdate/core.py
@@ -1696,6 +1696,10 @@ def variational_dates(
         disable=not progress,
     ):
         dynamic_prog.iterate(max_shape=max_shape, min_kl=min_kl, debug=debug)
+    # (DEBUG) check how many messages were skipped
+    skipped = np.sum(np.isnan(dynamic_prog.log_partition))
+    print("Skipped", skipped, "messages")
+    # (END DEBUG)
 
     posterior = priors.clone_with_new_data(
         grid_data=dynamic_prog.posterior[priors.nonfixed_nodes, :]

--- a/tsdate/core.py
+++ b/tsdate/core.py
@@ -1281,12 +1281,6 @@ def date(
         from the inside algorithm in addition to the dated tree sequence. If
         ``return_posteriors`` is also ``True``, then the marginal likelihood
         will be the last element of the tuple.
-    :param bool method_of_moments: If ``True`` match central moments in variational gamma
-        algorithm, otherwise match sufficient statistics. Matching central moments
-        is faster, but introduces a small amount of bias. Default: ``False``.
-    :param float max_shape: The maximum allowed shape for the posterior in the
-        variational gamma algorithm. The shape parameter is the inverse of the
-        variance for ``log(age)``. Default: ``1000``.
     :param float eps: Specify minimum distance separating time points. Also specifies
         the error factor in time difference calculations. Default: 1e-6
     :param int num_threads: The number of threads to use. A simpler unthreaded algorithm
@@ -1311,6 +1305,16 @@ def date(
         "inside_outside" estimation ``method`` and/or the marginal likelihood
         from the inside algorithm.
     :rtype: tskit.TreeSequence or (tskit.TreeSequence, dict)
+    """
+
+    # TODO: docstrings for variational gamma parameters
+    """
+    :param bool method_of_moments: If ``True`` match central moments in variational gamma
+        algorithm, otherwise match sufficient statistics. Matching central moments
+        is faster, but introduces a small amount of bias. Default: ``False``.
+    :param float max_shape: The maximum allowed shape for the posterior in the
+        variational gamma algorithm. The shape parameter is the inverse of the
+        variance for ``log(age)``. Default: ``1000``.
     """
 
     # check valid method - raise error if unknown.

--- a/tsdate/core.py
+++ b/tsdate/core.py
@@ -1011,9 +1011,7 @@ class ExpectationPropagation(InOutAlgorithms):
         return internal, external
 
     @staticmethod
-    @numba.njit(
-        "f8(i4[:, :], f8[:, :], f8[:, :], f8[:, :, :], f8[:], f8[:], f8, b1, b1)"
-    )
+    @numba.njit("f8(i4[:, :], f8[:, :], f8[:, :], f8[:, :, :], f8[:], f8[:], f8, b1)")
     def propagate(
         edges,
         likelihoods,

--- a/tsdate/core.py
+++ b/tsdate/core.py
@@ -1023,7 +1023,6 @@ class ExpectationPropagation(InOutAlgorithms):
         log_partition,
         max_shape,
         min_kl,
-        debug,
     ):
         """
         Update approximating factors for each edge, returning average relative
@@ -1066,61 +1065,41 @@ class ExpectationPropagation(InOutAlgorithms):
             return d
 
         for i, p, c in edges:
-            if debug:
-                print("---\nedge:", i, "parent:", p, "child:", c)
             # Damped downdate to ensure proper cavity distributions
             parent_message = messages[i, 0] * scale[p]
             child_message = messages[i, 1] * scale[c]
-            if debug:
-                print("p-mess:", parent_message, "c-mess:", child_message)
             parent_delta = cavity_damping(posterior[p], parent_message)
             child_delta = cavity_damping(posterior[c], child_message)
             delta = min(parent_delta, child_delta)
-            if debug:
-                print("delta:", delta)
             # The cavity posteriors: the approximation omitting the variational
             # factors for this edge.
             parent_cavity = posterior[p] - delta * parent_message
             child_cavity = posterior[c] - delta * child_message
-            if debug:
-                print("p-cavi:", parent_cavity, "c-cavi:", child_cavity)
             # The edge likelihood, scaled by the damping factor
             edge_likelihood = delta * likelihoods[i]
-            if debug:
-                print("e-like:", edge_likelihood)
             # The target posterior: the cavity multiplied by the edge
             # likelihood then projected onto a gamma via moment matching.
             logconst, parent_post, child_post = approx.gamma_projection(
                 parent_cavity, child_cavity, edge_likelihood, min_kl
             )
-            if debug:
-                print("logconst:", logconst)
-            if debug:
-                print("p-post:", parent_post, "c-post:", child_post)
             # The messages: the difference in natural parameters between the
             # target and cavity posteriors.
             messages[i, 0] += (parent_post - posterior[p]) / scale[p]
             messages[i, 1] += (child_post - posterior[c]) / scale[c]
-            if debug:
-                print("p-updt:", messages[i, 0], "c-updt:", messages[i, 1])
             # Contribution to the marginal likelihood from the edge
             log_partition[i] = logconst  # TODO: incomplete
             # Constrain the messages so that the gamma shape parameter for each
             # posterior is bounded (e.g. set a maximum precision for log(age)).
             parent_eta = posterior_damping(parent_post)
             child_eta = posterior_damping(child_post)
-            if debug:
-                print("p-scal:", parent_eta, "c-scal:", child_eta)
             posterior[p] = parent_eta * parent_post
             posterior[c] = child_eta * child_post
             scale[p] *= parent_eta
             scale[c] *= child_eta
-            if debug:
-                print("p-end:", posterior[p], "c-end:", posterior[c])
 
         return 0.0  # TODO, placeholder
 
-    def iterate(self, max_shape=1000, min_kl=True, debug=False):
+    def iterate(self, max_shape=1000, min_kl=True):
         """
         Update edge factors from leaves to root then from root to leaves,
         and return approximate log marginal likelihood (TODO)
@@ -1135,7 +1114,6 @@ class ExpectationPropagation(InOutAlgorithms):
             self.log_partition,
             max_shape,
             min_kl,
-            debug,
         )
         self.propagate(
             self.edges[::-1],
@@ -1146,7 +1124,6 @@ class ExpectationPropagation(InOutAlgorithms):
             self.log_partition,
             max_shape,
             min_kl,
-            debug,
         )
 
         # TODO
@@ -1599,7 +1576,6 @@ def variational_dates(
     num_threads=None,  # Unused, matches get_dates()
     probability_space=None,  # Can only be None, simply to match get_dates()
     ignore_oldest_root=False,  # Can only be False, simply to match get_dates()
-    debug=False,  # Print a ton of extra information
 ):
     """
     Infer dates for the nodes in a tree sequence using expectation propagation,
@@ -1695,11 +1671,11 @@ def variational_dates(
         desc="Expectation Propagation",
         disable=not progress,
     ):
-        dynamic_prog.iterate(max_shape=max_shape, min_kl=min_kl, debug=debug)
-    # (DEBUG) check how many messages were skipped
-    skipped = np.sum(np.isnan(dynamic_prog.log_partition))
-    print("Skipped", skipped, "messages")
-    # (END DEBUG)
+        dynamic_prog.iterate(max_shape=max_shape, min_kl=min_kl)
+
+    num_skipped = np.sum(np.isnan(dynamic_prog.log_partition))
+    if num_skipped > 0:
+        logging.info(f"Skipped {num_skipped} messages with invalid posterior updates.")
 
     posterior = priors.clone_with_new_data(
         grid_data=dynamic_prog.posterior[priors.nonfixed_nodes, :]

--- a/tsdate/hypergeo.py
+++ b/tsdate/hypergeo.py
@@ -38,19 +38,19 @@ _dbl = ctypes.c_double
 _ptr_dbl = _PTR(_dbl)
 _gammaln_addr = get_cython_function_address("scipy.special.cython_special", "gammaln")
 _gammaln_functype = ctypes.CFUNCTYPE(_dbl, _dbl)
-_gammaln_float64 = _gammaln_functype(_gammaln_addr)
+_gammaln_f8 = _gammaln_functype(_gammaln_addr)
 
 
 class Invalid2F1(Exception):
     pass
 
 
-@numba.njit("float64(float64)")
+@numba.njit("f8(f8)")
 def _gammaln(x):
-    return _gammaln_float64(x)
+    return _gammaln_f8(x)
 
 
-@numba.njit("float64(float64)")
+@numba.njit("f8(f8)")
 def _digamma(x):
     """
     Digamma (psi) function, from asymptotic series expansion.
@@ -74,7 +74,7 @@ def _digamma(x):
     )
 
 
-@numba.njit("float64(float64)")
+@numba.njit("f8(f8)")
 def _trigamma(x):
     """
     Trigamma function, from asymptotic series expansion
@@ -100,12 +100,12 @@ def _trigamma(x):
     )
 
 
-@numba.njit("float64(float64, float64)")
+@numba.njit("f8(f8, f8)")
 def _betaln(p, q):
     return _gammaln(p) + _gammaln(q) - _gammaln(p + q)
 
 
-@numba.njit("boolean(float64, float64, float64, float64, float64, float64, float64)")
+@numba.njit("b1(f8, f8, f8, f8, f8, f8, f8)")
 def _is_valid_2f1(f1, f2, a, b, c, z, tol):
     """
     Use the contiguous relation between the Gauss hypergeometric function and
@@ -127,7 +127,7 @@ def _is_valid_2f1(f1, f2, a, b, c, z, tol):
     return numer / denom < tol
 
 
-@numba.njit("UniTuple(float64, 5)(float64, float64, float64, float64)")
+@numba.njit("UniTuple(f8, 5)(f8, f8, f8, f8)")
 def _hyp2f1_taylor_series(a, b, c, z):
     """
     Evaluate a Gaussian hypergeometric function, via its Taylor series at the
@@ -198,7 +198,7 @@ def _hyp2f1_taylor_series(a, b, c, z):
     return val, da, db, dc, dz
 
 
-@numba.njit("UniTuple(float64, 5)(float64, float64, float64, float64)")
+@numba.njit("UniTuple(f8, 5)(f8, f8, f8, f8)")
 def _hyp2f1_laplace_approx(a, b, c, x):
     """
     Approximate a Gaussian hypergeometric function, using Laplace's method
@@ -269,7 +269,50 @@ def _hyp2f1_laplace_approx(a, b, c, x):
     return f, df_da, df_db, df_dc, df_dx
 
 
-# @numba.njit("UniTuple(float64, 5)(float64, float64, float64, float64)")
+@numba.njit("f8(f8, f8, f8, f8)")
+def _hyp2f1_fast(a, b, c, x):
+    """
+    Approximate a Gaussian hypergeometric function, using Laplace's method
+    as per Butler & Wood 2002 Annals of Statistics.
+
+    Shortcut bypassing the lengthly derivative computation.
+    """
+
+    assert c > 0.0
+    assert a >= 0.0
+    assert b >= 0.0
+    assert c >= a
+    assert x < 1.0
+
+    if x == 0.0:
+        return 0.0
+
+    s = 0.0
+    if x < 0.0:
+        s = -b * log(1 - x)
+        a = c - a
+        x = x / (x - 1)
+
+    t = x * (b - a) - c
+    u = np.sqrt(t**2 - 4 * a * x * (c - b)) - t
+    y = 2 * a / u
+    yy = y**2 / a
+    my = (1 - y) ** 2 / (c - a)
+    ymy = x**2 * b * yy * my / (1 - x * y) ** 2
+    r = yy + my - ymy
+    f = (
+        s
+        + (c - 1 / 2) * log(c)
+        - log(r) / 2
+        + a * (log(y) - log(a))
+        + (c - a) * (log(1 - y) - log(c - a))
+        - b * log(1 - x * y)
+    )
+
+    return f
+
+
+# @numba.njit("UniTuple(f8, 5)(f8, f8, f8, f8)")
 # def _hyp2f1_laplace_recurrence(a, b, c, x):
 #    """
 #    Use contiguous relations to stabilize the calculation of 2F1
@@ -305,9 +348,7 @@ def _hyp2f1_laplace_approx(a, b, c, x):
 #    return v, da, db, dc, dx
 
 
-@numba.njit(
-    "UniTuple(float64, 5)(float64, float64, float64, float64, float64, float64)"
-)
+@numba.njit("UniTuple(f8, 5)(f8, f8, f8, f8, f8, f8)")
 def _hyp2f1_dlmf1581(a_i, b_i, a_j, b_j, y, mu):
     """
     DLMF 15.8.1, series expansion with Pfaff transformation
@@ -332,9 +373,7 @@ def _hyp2f1_dlmf1581(a_i, b_i, a_j, b_j, y, mu):
     return val, da_i, db_i, da_j, db_j
 
 
-@numba.njit(
-    "UniTuple(float64, 5)(float64, float64, float64, float64, float64, float64)"
-)
+@numba.njit("UniTuple(f8, 5)(f8, f8, f8, f8, f8, f8)")
 def _hyp2f1_dlmf1521(a_i, b_i, a_j, b_j, y, mu):
     """
     DLMF 15.2.1, series expansion without transformation
@@ -356,9 +395,7 @@ def _hyp2f1_dlmf1521(a_i, b_i, a_j, b_j, y, mu):
     return val, da_i, db_i, da_j, db_j
 
 
-@numba.njit(
-    "UniTuple(float64, 5)(float64, float64, float64, float64, float64, float64)"
-)
+@numba.njit("UniTuple(f8, 5)(f8, f8, f8, f8, f8, f8)")
 def _hyp2f1(a_i, b_i, a_j, b_j, y, mu):
     """
     Evaluates:

--- a/tsdate/hypergeo.py
+++ b/tsdate/hypergeo.py
@@ -215,7 +215,7 @@ def _hyp2f1_laplace_approx(a, b, c, x):
     assert c >= a
     assert 1.0 > x >= 0.0
 
-    if np.isclose(x, 0.0):
+    if x == 0.0:
         return 0.0, 0.0, 0.0, 0.0, a * b / c
 
     # Equations 19, 24, 25 in Butler & Wood
@@ -284,7 +284,7 @@ def _hyp2f1_fast(a, b, c, x):
     assert c >= a
     assert x < 1.0
 
-    if np.isclose(x, 0.0):
+    if x == 0.0:
         return 0.0
 
     s = 0.0
@@ -417,7 +417,7 @@ def _hyp2f1(a_i, b_i, a_j, b_j, y, mu):
     and dividing the gradient by the function value.
     """
     z = (mu - b_j) / (mu + b_i)
-    assert z < 1.0 and not np.isclose(z, 1.0), "Invalid argument"
+    assert z < 1.0, "Invalid argument"
     if z > 0.0:
         return _hyp2f1_dlmf1521(a_i, b_i, a_j, b_j, y, mu)
     else:


### PR DESCRIPTION
This adds (or rather documents) an option `min_kl`, which if set to False matches central moments rather than sufficient statistics. This is around 2-3 times faster, but introduces some upward bias in the ages of very young nodes.