### PR TITLE
Refactor/redocument API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@
   `action="count"`, so `-v` turns verbosity to INFO level,
   whereas `-vv` turns verbosity to DEBUG level.
 
+- The `return_posteriors=True` option with `method="inside_outside"`
+  previously returned a dict that included keys `start_time` and `end_time`,
+  giving the impression that the posterior for node age is discretized over
+  time slices in this algorithm. In actuality, the posterior is discretized
+  atomically over time points, so `start_time` and `end_time` have been
+  replaced by a single key `time`.
+
 - Python 3.7 is no longer supported.
 
 **Features**

--- a/docs/priors.md
+++ b/docs/priors.md
@@ -54,7 +54,7 @@ See below for more explanation of the interpretation of the parameters passed to
 For {ref}`sec_methods_discrete_time` methods, it is possible to switch from the
 (default) lognormal approximation to a gamma distribution, used when building a
 mixture prior for nodes that have variable numbers of children in different
-genomic regions. The discretized prior is then constructed by evaluating the
+genomic regions. The discretised prior is then constructed by evaluating the
 lognormal (or gamma) distribution across a grid of fixed times. Tests have shown that the
 lognormal is usually a better fit to the true prior in most cases.
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -25,6 +25,8 @@ This page provides formal documentation for the `tsdate` Python API.
 
 ```{eval-rst}
 .. autofunction:: tsdate.date
+.. autofunction:: tsdate.discretised_dates
+.. autofunction:: tsdate.variational_dates
 ```
 
 ## Prior and Time Discretisation Options

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -255,7 +255,7 @@ different stages of dating will take.
 
 If the {ref}`method<sec_methods>` used for dating involves discrete time slices, `tsdate` scales
 quadratically in the number of time slices chosen. For greater temporal resolution,
-you are thus advised to use the `variational_gamma` method, which does not discretize time.
+you are thus advised to use the `variational_gamma` method, which does not discretise time.
 
 #### Optimisations
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -41,11 +41,11 @@ import tsdate
 from tsdate import base
 from tsdate.core import constrain_ages_topo
 from tsdate.core import date
-from tsdate.core import get_dates
+from tsdate.core import discretised_dates
+from tsdate.core import discretised_mean_var
 from tsdate.core import InOutAlgorithms
 from tsdate.core import Likelihoods
 from tsdate.core import LogLikelihoods
-from tsdate.core import posterior_mean_var
 from tsdate.core import variational_dates
 from tsdate.core import VariationalLikelihoods
 from tsdate.demography import PopulationSizeHistory
@@ -500,7 +500,7 @@ class TestMixturePrior:
         prior = MixturePrior(ts)
         demography = PopulationSizeHistory(3)
         timepoints = np.array([0, 300, 1000, 2000])
-        prior_grid = prior.make_discretized_prior(demography, timepoints=timepoints)
+        prior_grid = prior.make_discretised_prior(demography, timepoints=timepoints)
         assert np.array_equal(prior_grid.timepoints, timepoints)
 
 
@@ -1602,35 +1602,16 @@ class TestBuildPriorGrid:
             tsdate.build_prior_grid(ts, population_size=-10)
 
 
-class TestCallingErrors:
-    def test_bad_vgamma_probability_space(self):
-        ts = utility_functions.single_tree_ts_n2()
-        with pytest.raises(ValueError, match="Cannot specify"):
-            variational_dates(ts, 1, 1, probability_space=base.LOG)
-
-    def test_bad_vgamma_num_threads(self):
-        # Test can be removed if we specify num_threads in the future
-        ts = utility_functions.single_tree_ts_n2()
-        with pytest.raises(ValueError, match="does not currently"):
-            variational_dates(ts, 1, 1, num_threads=2)
-
-    def test_bad_vgamma_ignore_oldest_root(self):
-        # Test can be removed in the future if this is implemented
-        ts = utility_functions.single_tree_ts_n2()
-        with pytest.raises(ValueError, match="not implemented"):
-            variational_dates(ts, 1, 1, ignore_oldest_root=True)
-
-
-class TestPosteriorMeanVar:
+class TestDiscretisedMeanVar:
     """
-    Test posterior_mean_var works as expected
+    Test discretised_mean_var works as expected
     """
 
-    def test_posterior_mean_var(self):
+    def test_discretised_mean_var(self):
         ts = utility_functions.single_tree_ts_n2()
         for distr in ("gamma", "lognorm"):
             posterior, algo = TestTotalFunctionalValueTree().find_posterior(ts, distr)
-            ts_node_metadata, mn_post, vr_post = posterior_mean_var(ts, posterior)
+            mn_post, vr_post = discretised_mean_var(ts, posterior)
             assert np.array_equal(
                 mn_post,
                 [
@@ -1640,19 +1621,12 @@ class TestPosteriorMeanVar:
                 ],
             )
 
-    def test_node_metadata_single_tree_n2(self):
-        ts = utility_functions.single_tree_ts_n2()
-        posterior, algo = TestTotalFunctionalValueTree().find_posterior(ts, "lognorm")
-        ts_node_metadata, mn_post, vr_post = posterior_mean_var(ts, posterior)
-        assert json.loads(ts_node_metadata.node(2).metadata)["mn"] == mn_post[2]
-        assert json.loads(ts_node_metadata.node(2).metadata)["vr"] == vr_post[2]
-
     def test_node_metadata_simulated_tree(self):
         larger_ts = msprime.simulate(
             10, mutation_rate=1, recombination_rate=1, length=20, random_seed=12
         )
-        _, mn_post, _, _, eps, _, _ = get_dates(
-            larger_ts, mutation_rate=None, population_size=10000
+        mn_post, *_ = discretised_dates(
+            larger_ts, mutation_rate=None, population_size=10000, eps=1e-6
         )
         dated_ts = date(larger_ts, population_size=10000, mutation_rate=None)
         metadata = dated_ts.tables.nodes.metadata
@@ -1866,8 +1840,8 @@ class TestSiteTimes:
     def test_sites_time_insideoutside(self):
         ts = utility_functions.two_tree_mutation_ts()
         dated = tsdate.date(ts, mutation_rate=None, population_size=1)
-        _, mn_post, _, _, eps, _, _ = get_dates(
-            ts, mutation_rate=None, population_size=1
+        mn_post, *_ = discretised_dates(
+            ts, mutation_rate=None, population_size=1, eps=1e-6
         )
         assert np.array_equal(
             mn_post[ts.tables.mutations.node],
@@ -1971,7 +1945,7 @@ class TestSiteTimes:
         larger_ts = msprime.simulate(
             10, mutation_rate=1, recombination_rate=1, length=20, random_seed=12
         )
-        _, mn_post, _, _, _, _, _ = get_dates(
+        mn_post, *_ = discretised_dates(
             larger_ts, mutation_rate=None, population_size=10000
         )
         dated = date(larger_ts, mutation_rate=None, population_size=10000)

--- a/tsdate/__init__.py
+++ b/tsdate/__init__.py
@@ -21,7 +21,8 @@
 # SOFTWARE.
 from .cache import *  # NOQA: F401,F403
 from .core import date  # NOQA: F401
-from .core import get_dates  # NOQA: F401
+from .core import discretised_dates  # NOQA: F401
+from .core import variational_dates  # NOQA: F401
 from .prior import build_grid as build_prior_grid  # NOQA: F401
 from .prior import parameter_grid as build_parameter_grid  # NOQA: F401
 from .provenance import __version__  # NOQA: F401

--- a/tsdate/cli.py
+++ b/tsdate/cli.py
@@ -53,8 +53,10 @@ def setup_logging(args):
 
 def tsdate_cli_parser():
     top_parser = argparse.ArgumentParser(
-        description="This is the command line interface for tsdate, a tool to date \
-                tree sequences."
+        description=(
+            "This is the command line interface for tsdate, a tool to date "
+            "tree sequences."
+        ),
     )
     top_parser.add_argument(
         "-V", "--version", action="version", version=f"%(prog)s {tsdate.__version__}"
@@ -73,65 +75,79 @@ def tsdate_cli_parser():
 
     parser.add_argument(
         "tree_sequence",
-        help="The path and name of the input tree sequence from which \
-                        we estimate node ages.",
+        help=(
+            "The path and name of the input tree sequence for which "
+            "node ages are estimated."
+        ),
     )
     parser.add_argument(
         "output",
-        help="The path and name of output file where the dated tree \
-                        sequence will saved.",
+        help=(
+            "The path and name of output file where the dated tree "
+            "sequence will saved."
+        ),
     )
     # TODO array specification from file?
     parser.add_argument(
         "population_size",
         type=float,
-        help="estimated effective (diploid) population size.",
+        help="Estimated effective (diploid) population size.",
     )
     parser.add_argument(
         "-m",
         "--mutation-rate",
         type=float,
         default=None,
-        help="The estimated mutation rate per unit of genome per \
-                        generation. If provided, the dating algorithm will use a \
-                        mutation rate clock to help estimate node dates. Default: None",
+        help=(
+            "The estimated mutation rate per unit of genome per "
+            "generation. If provided, the dating algorithm will use a "
+            "mutation rate clock to help estimate node dates. Default: None"
+        ),
     )
     parser.add_argument(
         "-r",
         "--recombination-rate",
         type=float,
         default=None,
-        help="The estimated recombination rate per unit \
-                        of genome per generation. If provided, the dating algorithm \
-                        will  use a recombination rate clock to help estimate node \
-                        dates. Default: None",
+        help=(
+            "The estimated recombination rate per unit "
+            "of genome per generation. If provided, the dating algorithm "
+            "will use a recombination rate clock to help estimate node "
+            "dates. Default: None"
+        ),
     )
     parser.add_argument(
         "-e",
         "--epsilon",
         type=float,
         default=1e-6,
-        help="Specify minimum distance separating time points. Also \
-                        specifies the error factor in time difference calculations. \
-                        Default: 1e-6",
+        help=(
+            "Specify minimum distance separating time points. Also "
+            "specifies the error factor in time difference calculations. "
+            "Default: 1e-6"
+        ),
     )
     parser.add_argument(
         "-t",
         "--num-threads",
         type=int,
         default=None,
-        help="The number of threads to use. A simpler unthreaded \
-                        algorithm is used unless this is >= 1. Default: None",
+        help=(
+            "The number of threads to use. A simpler unthreaded algorithm "
+            "is used unless this is >= 1. Not relevant for the 'variational_gamma' "
+            "method. Default: None"
+        ),
     )
     parser.add_argument(
         "--probability-space",
         type=str,
         default=None,
-        help="Should the internal algorithm save probabilities in \
-                        'logarithmic' (slower, less liable to to overflow) or 'linear' \
-                        space (faster, may overflow). Not relevant for the \
-                        'variational_gamma' method; default otherwise is `None` \
-                        currently treated as 'logarithmic'",
+        help=(
+            "Should the internal algorithm save probabilities in "
+            "'logarithmic' (slower, less liable to to overflow) or 'linear' "
+            "space (faster, may overflow). Not relevant for the "
+            "'variational_gamma' method. Default: 'logarithmic'"
+        ),
     )
     parser.add_argument(
         "--method",
@@ -139,17 +155,19 @@ def tsdate_cli_parser():
         default="inside_outside",
         help=(
             "Specify which estimation method to use: "
-            "'inside_outside' is empirically better, but theoretically problematic, "
+            "'inside_outside' is empirically better, but theoretically problematic; "
             "'maximization' is worse empirically, especially with a gamma prior, but "
-            "theoretically robust), 'variational_gamma' is a fast experimental "
-            "continuous-time approximation). Current default: 'inside_outside'",
+            "theoretically robust; 'variational_gamma' is a fast experimental "
+            "continuous-time approximation. Current default: 'inside_outside'"
         ),
     )
     parser.add_argument(
         "--ignore-oldest",
         action="store_true",
-        help="Ignore the oldest node in the tree sequence: in older tsinfer versions \
-                        this could be of low quality when using empirical data.",
+        help=(
+            "Ignore the oldest node in the tree sequence: in older tsinfer versions "
+            "this could be of low quality when using empirical data."
+        ),
     )
     parser.add_argument(
         "-p", "--progress", action="store_true", help="Show progress bar."
@@ -161,6 +179,26 @@ def tsdate_cli_parser():
         default=0,
         help="How much verbosity to output.",
     )
+    parser.add_argument(
+        "--max-shape",
+        type=float,
+        help=(
+            "The maximum value for the shape parameter in the variational "
+            'posteriors for the "variational_gamma" algorithm. This is '
+            "equivalent to the maximum precision (inverse variance) on a "
+            "logarithmic scale. Default: 1000"
+        ),
+        default=1000,
+    )
+    parser.add_argument(
+        "--match-central-moments",
+        action="store_true",
+        help=(
+            "Match mean and variance rather than gamma sufficient statistics in "
+            'the "variational_gamma" algorithm. Faster with similar accuracy, '
+            "but does not exactly minimize KL divergence in each EP update."
+        ),
+    )
     parser.set_defaults(runner=run_date)
 
     parser = subparsers.add_parser(
@@ -169,22 +207,28 @@ def tsdate_cli_parser():
     parser.add_argument("tree_sequence", help="The tree sequence to preprocess.")
     parser.add_argument(
         "output",
-        help="The path and name of output file where the preprocessed \
-                        tree sequence will saved.",
+        help=(
+            "The path and name of output file where the preprocessed "
+            "tree sequence will saved."
+        ),
     )
     parser.add_argument(
         "--minimum_gap",
         type=float,
-        help="The minimum gap between sites to trim from the tree \
-                        sequence. Default: '1000000'",
+        help=(
+            "The minimum gap between sites to trim from the tree "
+            "sequence. Default: 1000000"
+        ),
         default=1000000,
     )
     parser.add_argument(
         "--trim-telomeres",
         type=bool,
-        help="Should all material before the first site and after the \
-                        last site be trimmed, regardless of the length of these \
-                        regions. Default: 'True'",
+        help=(
+            "Should all material before the first site and after the "
+            "last site be trimmed, regardless of the length of these "
+            "regions. Default: True"
+        ),
         default=True,
     )
     parser.add_argument(
@@ -203,17 +247,27 @@ def run_date(args):
         ts = tskit.load(args.tree_sequence)
     except tskit.FileFormatError as ffe:
         error_exit(f"FileFormatError loading '{args.tree_sequence}: {ffe}")
-    params = dict(
-        recombination_rate=args.recombination_rate,
-        method=args.method,
-        eps=args.epsilon,
-        progress=args.progress,
-        probability_space=args.probability_space,
-        num_threads=args.num_threads,
-        ignore_oldest_root=args.ignore_oldest,
-    )
-    # TODO: error out if ignore_oldest_root is set,
-    # see https://github.com/tskit-dev/tsdate/issues/262
+    if args.method == "variational_gamma":
+        params = dict(
+            recombination_rate=args.recombination_rate,
+            method=args.method,
+            eps=args.epsilon,
+            progress=args.progress,
+            max_shape=args.max_shape,
+            match_central_moments=args.match_central_moments,
+        )
+    else:
+        params = dict(
+            recombination_rate=args.recombination_rate,
+            method=args.method,
+            eps=args.epsilon,
+            progress=args.progress,
+            probability_space=args.probability_space,
+            num_threads=args.num_threads,
+            ignore_oldest_root=args.ignore_oldest,
+        )
+        # TODO: error out if ignore_oldest_root is set,
+        # see https://github.com/tskit-dev/tsdate/issues/262
     dated_ts = tsdate.date(ts, args.mutation_rate, args.population_size, **params)
     dated_ts.dump(args.output)
 

--- a/tsdate/prior.py
+++ b/tsdate/prior.py
@@ -1055,7 +1055,7 @@ def fill_priors(
 class MixturePrior:
     """
     Maps ConditionalCoalescentPrior onto nodes in a tree sequence and creates
-    time-discretized priors
+    time-discretised priors
     """
 
     def __init__(
@@ -1104,7 +1104,7 @@ class MixturePrior:
         self.tree_sequence = tree_sequence
         self.prior_distribution = prior_distribution
 
-    def make_discretized_prior(self, population_size, timepoints=20, progress=False):
+    def make_discretised_prior(self, population_size, timepoints=20, progress=False):
         """
         Calculate prior grid for a set of timepoints and a population size history
         """
@@ -1239,7 +1239,7 @@ def build_grid(
         allow_unary,
         progress,
     )
-    return mixture_prior.make_discretized_prior(population_size, timepoints)
+    return mixture_prior.make_discretised_prior(population_size, timepoints)
 
 
 def parameter_grid(


### PR DESCRIPTION
- Make `get_dates` and `variational_dates` part of the public API, that will return unconstrained node ages and posteriors. Rename `get_dates` to `discretised_dates`. The main method `date` calls one of these functions and inserts constrained dates into the tree sequence.
- Moves docstrings for method specific arguments into `discretised_dates` and `variational_dates`. Shared arguments are documented in `date`.
- In the docstrings, the posteriors from the inside-outside algo are referred to as being over 'time slices'. This isn't really correct, the likelihood is evaluated at fixed time points rather than integrated over a time interval. So have changed docstrings accordingly. (It's a little confusing because the default prior is calculated over intervals from a CDF, but given that arbitrary priors could be used, this change seems like the right choice.) Accordingly, the returned posteriors now have a single key `time` instead of `start_time` and `end_time`.
- Some miscellaneous refactoring/cleanup.