### PR TITLE
Api extras

### DIFF
--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -25,8 +25,11 @@ This page provides formal documentation for the `tsdate` Python API.
 
 ```{eval-rst}
 .. autofunction:: tsdate.date
-.. autofunction:: tsdate.discretised_dates
-.. autofunction:: tsdate.variational_dates
+.. autodata:: tsdate.core.estimation_methods
+   :no-value:
+.. autofunction:: tsdate.inside_outside
+.. autofunction:: tsdate.maximization
+.. autofunction:: tsdate.variational_gamma
 ```
 
 ## Prior and Time Discretisation Options
@@ -34,9 +37,7 @@ This page provides formal documentation for the `tsdate` Python API.
 ```{eval-rst}
 .. autofunction:: tsdate.build_prior_grid
 .. autofunction:: tsdate.build_parameter_grid
-
 .. autoclass:: tsdate.base.NodeGridValues
-
 .. autodata:: tsdate.base.DEFAULT_APPROX_PRIOR_SIZE
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ tqdm
 daiquiri
 msprime>=1.0.0
 scipy
-numba>=0.58.0
+numba>=0.58.1
 appdirs
 pre-commit
 pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     numpy
     tskit>=0.2.3
     scipy>1.2.3
-    numba>=0.46.0
+    numba>=0.58.1
     mpmath
     tqdm
     appdirs

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1629,7 +1629,9 @@ class TestDiscretisedMeanVar:
         algorithm = InsideOutsideMethod(
             larger_ts, mutation_rate=None, population_size=10000
         )
-        mn_post, *_ = algorithm.run(eps=1e-6, outside_standardize=True)
+        mn_post, *_ = algorithm.run(
+            eps=1e-6, outside_standardize=True, probability_space=tsdate.base.LOG
+        )
         dated_ts = date(larger_ts, population_size=10000, mutation_rate=None)
         metadata = dated_ts.tables.nodes.metadata
         metadata_offset = dated_ts.tables.nodes.metadata_offset
@@ -1843,7 +1845,9 @@ class TestSiteTimes:
         ts = utility_functions.two_tree_mutation_ts()
         dated = tsdate.date(ts, mutation_rate=None, population_size=1)
         algorithm = InsideOutsideMethod(ts, mutation_rate=None, population_size=1)
-        mn_post, *_ = algorithm.run(eps=1e-6, outside_standardize=True)
+        mn_post, *_ = algorithm.run(
+            eps=1e-6, outside_standardize=True, probability_space=tsdate.base.LOG
+        )
         assert np.array_equal(
             mn_post[ts.tables.mutations.node],
             tsdate.sites_time_from_ts(dated, unconstrained=True, min_time=0),

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -121,14 +121,14 @@ class TestPrebuilt:
 
     def test_no_posteriors(self):
         ts = utility_functions.two_tree_mutation_ts()
-        ts, posteriors = tsdate.date(
-            ts,
-            population_size=1,
-            return_posteriors=True,
-            method="maximization",
-            mutation_rate=1,
-        )
-        assert posteriors is None
+        with pytest.raises(ValueError, match="Cannot return posterior"):
+            tsdate.date(
+                ts,
+                population_size=1,
+                return_posteriors=True,
+                method="maximization",
+                mutation_rate=1,
+            )
 
     def test_discretised_posteriors(self):
         ts = utility_functions.two_tree_mutation_ts()
@@ -327,7 +327,7 @@ class TestSimulated:
             msprime.Sample(population=0, time=1.0),
         ]
         ts = msprime.simulate(samples=samples, Ne=1, mutation_rate=2, random_seed=12)
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(ValueError, match="noncontemporaneous"):
             tsdate.date(ts, population_size=1, mutation_rate=2)
 
     def test_no_mutation_times(self):

--- a/tsdate/__init__.py
+++ b/tsdate/__init__.py
@@ -21,10 +21,11 @@
 # SOFTWARE.
 from .cache import *  # NOQA: F401,F403
 from .core import date  # NOQA: F401
-from .core import discretised_dates  # NOQA: F401
-from .core import variational_dates  # NOQA: F401
-from .prior import build_grid as build_prior_grid  # NOQA: F401
+from .core import inside_outside  # NOQA: F401
+from .core import maximization  # NOQA: F401
+from .core import variational_gamma  # NOQA: F401
 from .prior import parameter_grid as build_parameter_grid  # NOQA: F401
+from .prior import prior_grid as build_prior_grid  # NOQA: F401
 from .provenance import __version__  # NOQA: F401
 from .util import add_sampledata_times  # NOQA: F401
 from .util import preprocess_ts  # NOQA: F401

--- a/tsdate/base.py
+++ b/tsdate/base.py
@@ -241,3 +241,9 @@ class NodeGridValues:
         else:
             new_obj.probability_space = probability_space
         return new_obj
+
+    def nonfixed_dict(self):
+        """
+        Return a dictionary mapping integer node ids to their data.
+        """
+        return {n: self[n] for n in self.nonfixed_nodes}

--- a/tsdate/cli.py
+++ b/tsdate/cli.py
@@ -264,9 +264,10 @@ def run_date(args):
             progress=args.progress,
             probability_space=args.probability_space,
             num_threads=args.num_threads,
-            ignore_oldest_root=args.ignore_oldest,
         )
-        # TODO: error out if ignore_oldest_root is set,
+        if args.method == "inside_outside":
+            params["ignore_oldest_root"] = args.ignore_oldest  # For backwards compat
+        # TODO: remove and error out if ignore_oldest_root is set,
         # see https://github.com/tskit-dev/tsdate/issues/262
     dated_ts = tsdate.date(ts, args.mutation_rate, args.population_size, **params)
     dated_ts.dump(args.output)

--- a/tsdate/prior.py
+++ b/tsdate/prior.py
@@ -1184,7 +1184,7 @@ class MixturePrior:
         return prior_pars
 
 
-def build_grid(
+def prior_grid(
     tree_sequence,
     population_size,
     timepoints=20,
@@ -1193,7 +1193,6 @@ def build_grid(
     approx_prior_size=None,
     prior_distribution="lognorm",
     # Parameters below undocumented
-    eps=1e-6,  # placeholder
     progress=False,
     allow_unary=False,
 ):
@@ -1226,8 +1225,8 @@ def build_grid(
         better fit, but slightly slower to calculate) or "gamma" for the gamma
         distribution (slightly faster, but a poorer fit for recent nodes). Default:
         "lognorm"
-    :return: A prior object to pass to tsdate.date() containing prior values for
-        inference and a discretised time grid
+    :return: A prior object to pass to :func:`date` and similar functions containing
+        prior values for inference and a discretised time grid
     :rtype:  base.NodeGridValues
     """
 


### PR DESCRIPTION
Make `tsdate.date()` a wrapper for `tsdate.inside_outside()`, `tsdate.variational_gamma()`, or `tsdate.maximization()`. This allows easier documentation and reuse, and is a follow-up to #350 

Also ban `tsdate.maximization()` from using the `return_posteriors` parameter.