### PR TITLE
Add `set_metadata` parameter

### DIFF
--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -109,11 +109,6 @@ class TestAccuracy:
         mu = sim_mutations_parameters["rate"]
 
         dts = tsdate.inside_outside(ts, population_size=Ne, mutation_rate=mu)
-        # make sure we can read node metadata - old tsdate versions didn't set a schema
-        if dts.table_metadata_schemas.node.schema is None:
-            tables = dts.dump_tables()
-            tables.nodes.metadata_schema = tskit.MetadataSchema.permissive_json()
-            dts = tables.tree_sequence()
 
         # Only test nonsample node times
         nonsamples = np.ones(ts.num_nodes, dtype=bool)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -478,6 +478,13 @@ class TestVariational:
         with pytest.raises(ValueError, match="Maximum number of EP iterations"):
             tsdate.variational_gamma(self.ts, mutation_rate=5, max_iterations=-1)
 
+    def test_no_set_metadata(self):
+        assert len(self.ts.tables.mutations.metadata) == 0
+        assert len(self.ts.tables.nodes.metadata) == 0
+        ts = tsdate.variational_gamma(self.ts, mutation_rate=1e-8, set_metadata=False)
+        assert len(ts.tables.mutations.metadata) == 0
+        assert len(ts.tables.nodes.metadata) == 0
+
     def test_no_existing_mutation_metadata(self):
         # Currently only the variational_gamma method embeds mutation metadata
         ts = tsdate.variational_gamma(self.ts, mutation_rate=1e-8)
@@ -565,3 +572,7 @@ class TestVariational:
             dts = tsdate.variational_gamma(ts, mutation_rate=1e-8)
             assert "Could not set" in caplog.text
         assert len(dts.tables.mutations.metadata) == 0
+        assert len(dts.tables.nodes.metadata) > 0
+        dts = tsdate.variational_gamma(ts, mutation_rate=1e-8, set_metadata=True)
+        assert len(dts.tables.mutations.metadata) > 0
+        assert len(dts.tables.nodes.metadata) > 0


### PR DESCRIPTION
Fixes #302. As described in that issue, we issue a warning and don't write metadata for old tsinfer versions (these have no schema, and raw byte metadata in the nodes table)