### PR TITLE
replace constrain_mutations with the built in `compute_mutation_times`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [0.2.3] - 2025-XX-XX
 
+**Breaking changes**
+
+- All returned nodes are now forced to be at least epsilon apart, rather than
+  allowing some to be the next allowable floating point number. This allows room
+  for mutations. Epsilon has been changed to 1e-10 from 1e-6, to minimise the
+  impact, as this has the potential to (marginally) change the dates of internal
+  (fixed) sample nodes.
+
+- Multiple mutations at the same site above the same node are now spaced out evenly
+  in time, rather than placed at identical times.
 
 ## [0.2.2] - 2025-03-30
 

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -61,7 +61,7 @@
 
 @article{anderson-trocme2023genes,
   author = {Luke Anderson-Trocmé  and Dominic Nelson  and Shadi Zabad  and Alex Diaz-Papkovich  and Ivan Kryukov  and Nikolas Baya  and Mathilde Touvier  and Ben Jeffery  and Christian Dina  and Hélène Vézina  and Jerome Kelleher  and Simon Gravel },
-  title = {On the genes, genealogies, and geographies of Quebec},
+  title = {On the genes, genealogies, and geographies of {Quebec}},
   journal = {Science},
   volume = {380},
   pages = {849-855},

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,7 +57,7 @@ class TestTsdateArgParser:
         assert args.population_size is None
         assert args.mutation_rate is None
         assert args.recombination_rate is None
-        assert args.epsilon == 1e-6
+        assert args.epsilon == 1e-10
         assert args.num_threads is None
         assert args.probability_space is None  # Use the defaults
         assert args.method == "variational_gamma"

--- a/tsdate/util.py
+++ b/tsdate/util.py
@@ -613,7 +613,7 @@ def _constrain_ages(
     nodes_time = nodes_time.copy()
     edges_cavity = np.zeros((num_edges, 2))
     for _ in range(max_iterations):  # method of alternating projections
-        if np.all(nodes_time[edges_parent] - nodes_time[edges_child] > 0):
+        if np.all(nodes_time[edges_parent] - nodes_time[edges_child] > epsilon):
             return nodes_time
         for e in range(num_edges):
             p, c = edges_parent[e], edges_child[e]
@@ -642,7 +642,7 @@ def _constrain_ages(
     for e in range(num_edges):
         p, c = edges_parent[e], edges_child[e]
         # TODO: even if nodes_fixed[p], this will still change the age
-        if nodes_time[c] >= nodes_time[p]:
+        if nodes_time[c] + epsilon >= nodes_time[p]:
             nodes_time[p] = nodes_time[c] + epsilon
 
     return nodes_time

--- a/tsdate/util.py
+++ b/tsdate/util.py
@@ -688,38 +688,6 @@ def constrain_ages(ts, nodes_time, epsilon=1e-6, max_iterations=0):
     return constrained_nodes_time
 
 
-def constrain_mutations(ts, nodes_time, mutations_edge):
-    """
-    If the mutation is above a root, its age set to the age of the root. If
-    the mutation is between two internal nodes, the edge midpoint is used.
-
-    :param tskit.TreeSequence ts: The input tree sequence, with arbitrary node
-        times.
-    :param np.ndarray nodes_time: Constrained node ages.
-    :param np.ndarray mutations_edge: The edge that each mutation falls on.
-
-    :return np.ndarray: Constrained mutation ages
-    """
-
-    parent = ts.edges_parent[mutations_edge]
-    child = ts.edges_child[mutations_edge]
-    parent_time = nodes_time[parent]
-    child_time = nodes_time[child]
-    assert np.all(parent_time > child_time), "Negative branch lengths"
-
-    mutations_time = (child_time + parent_time) / 2
-    internal = mutations_edge != tskit.NULL
-    constrained_time = np.full(mutations_time.size, tskit.UNKNOWN_TIME)
-    constrained_time[internal] = mutations_time[internal]
-    constrained_time[~internal] = nodes_time[ts.mutations_node[~internal]]
-
-    external = np.sum(~internal)
-    if external:
-        logging.info(f"Set ages of {external} nonsegregating mutations to root times.")
-
-    return constrained_time
-
-
 @numba_jit(_b(_b1r, _i1r, _f1r, _f1r, _i1r, _i1r, _f, _i))
 def _contains_unary_nodes(
     nodes_mask,

--- a/tsdate/variational.py
+++ b/tsdate/variational.py
@@ -934,7 +934,7 @@ class ExpectationPropagation:
         # phase (if singletons were unphased)
 
         # TODO: should these be copies? Should members be readonly?
-        return self.mutation_edges, self.mutation_nodes
+        return self.mutation_nodes
 
     def marginal_likelihood(self):
         # Return the marginal likelihood of the data given the model


### PR DESCRIPTION
Fixes a problem when we have multiple mutations at the same site on the same edge (can't put them halfway between edge parent and edge child).