### PR TITLE
separate citation documentation into citation.md

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -14,5 +14,6 @@ chapters:
   sections:
   - file: python-api
   - file: cli
+- file: citation
 - file: bibliography
 - file: CHANGELOG

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -1,0 +1,33 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.12
+    jupytext_version: 1.9.1
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+:::{currentmodule} tsdate
+:::
+
+(sec_citation)=
+
+# Citation
+
+The algorithm for the `inside_outside` and `maximization` methods is described
+in [our Science paper](https://www.science.org/doi/10.1126/science.abi8264) (citation below,
+preprint [here](https://www.biorxiv.org/content/10.1101/2021.02.16.431497v2)).
+[Another repository](https://github.com/awohns/unified_genealogy_paper) provides
+code to reproduce evaluations of the accuracy and computational requirements of these methods.
+The default `variational_gamma` method has not yet been described in print. For the moment,
+please cite this github repository if you need a citable reference.
+
+The original _tsdate_ algorithm, which you should cite in published work, is published in:
+
+> Anthony Wilder Wohns, Yan Wong, Ben Jeffery, Ali Akbari, Swapan Mallick, Ron Pinhasi, Nick Patterson, David Reich, Jerome Kelleher, and Gil McVean (2022) *A unified genealogy of modern and ancient genomes*. Science **375**: eabi8264; doi: https://doi.org/10.1126/science.abi8264
+
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,16 +49,4 @@ Pull requests are welcome: we largely follow the
 [tskit development workflow](https://tskit.dev/tskit/docs/latest/development.html#workflow).
 
 ## Citing
-
-The algorithm for the `inside_outside` and `maximization` methods is described 
-in [our Science paper](https://www.science.org/doi/10.1126/science.abi8264) (citation below,
-preprint [here](https://www.biorxiv.org/content/10.1101/2021.02.16.431497v2)).
-[Another repository](https://github.com/awohns/unified_genealogy_paper) provides
-code to reproduce evaluations of the accuracy and computational requirements of these methods.
-The default `variational_gamma` method has not yet been described in print. For the moment,
-please cite this github repository if you need a citable reference.
-
-The original _tsdate_ algorithm, which you should cite in published work, is published in:
-
-> Anthony Wilder Wohns, Yan Wong, Ben Jeffery, Ali Akbari, Swapan Mallick, Ron Pinhasi, Nick Patterson, David Reich, Jerome Kelleher, and Gil McVean (2022) *A unified genealogy of modern and ancient genomes*. Science **375**: eabi8264; doi: https://doi.org/10.1126/science.abi8264
-
+To cite tsdate, please consult the citation manual at: [https://tskit.dev/tsdate/docs/stable/citation](https://tskit.dev/tsdate/docs/stable/citation)


### PR DESCRIPTION
separate citation documentation in a separate file.
This is done to display and reference the citation file in the common citation page for tskit-dev: https://tskit.dev/citation/